### PR TITLE
chore(NODE-6186): add downloading to FLE build script

### DIFF
--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -1,0 +1,11 @@
+ARG NODE_BUILD_IMAGE=node:16.20.1-bullseye
+FROM $NODE_BUILD_IMAGE AS build
+
+WORKDIR /mongodb-client-encryption
+COPY . .
+
+RUN node /mongodb-client-encryption/.github/scripts/libmongocrypt.mjs
+
+FROM scratch
+
+COPY --from=build /mongodb-client-encryption/prebuilds/ /

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -189,8 +189,11 @@ export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
 
   await fs.rm(nodeDepsRoot, { recursive: true, force: true });
   await fs.cp(resolveRoot(destination, prebuild, 'nocrypto'), nodeDepsRoot, { recursive: true });
-  if (await exists(path.join(nodeDepsRoot, 'lib64'))) {
-    await fs.rename(path.join(nodeDepsRoot, 'lib64'), path.join(nodeDepsRoot, 'lib'));
+  const currentPath = path.join(nodeDepsRoot, 'lib64');
+  try {
+    await fs.rename(currentPath, path.join(nodeDepsRoot, 'lib'));
+  } catch (error) {
+    console.error(`error renaming ${currentPath}: ${error.message}`);
   }
 }
 

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -162,7 +162,7 @@ if (!args.build) {
   const platform = platformMatrix[`${process.platform}-${process.arch}`];
   if (platform == null) throw new Error(`${process.platform}-${process.arch}`);
 
-  const unzip = child_process.spawn('tar', ['-xz', '-C', destination, ...new Set(Object.values(platformMatrix))], {
+  const unzip = child_process.spawn('tar', ['-xz', '-C', destination, `${platform}/nocrypto`], {
     stdio: ['pipe']
   });
 
@@ -176,6 +176,9 @@ if (!args.build) {
 
   await fs.rm('deps', { recursive: true, force: true });
   await fs.cp(path.join(destination, platform, 'nocrypto'), 'deps', { recursive: true });
+  if (await fs.access(path.join('deps', 'lib64')).then(() => true, () => false)) {
+    await fs.rename(path.join('deps', 'lib64'), path.join('deps', 'lib'));
+  }
 }
 
 await run('npm', ['install', '--ignore-scripts']);

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -56,11 +56,16 @@ async function parseArguments() {
 
 /** `xtrace` style command runner, uses spawn so that stdio is inherited */
 async function run(command, args = [], options = {}) {
-  console.error(`+ ${command} ${args.join(' ')}`, options.cwd ? `(in: ${options.cwd})` : '');
-  await events.once(
-    child_process.spawn(command, args, { stdio: 'inherit', cwd: resolveRoot('.'), ...options }),
-    'exit'
-  );
+  const commandDetails = `+ ${command} ${args.join(' ')}${options.cwd ? ` (in: ${options.cwd})` : ''}`;
+  console.error(commandDetails);
+  const proc = child_process.spawn(command, args, {
+    stdio: 'inherit',
+    cwd: resolveRoot('.'),
+    ...options
+  });
+  await events.once(proc, 'exit');
+
+  if (proc.exitCode != 0) throw new Error(`CRASH(${proc.exitCode}): ${commandDetails}`);
 }
 
 /** CLI flag maker: `toFlags({a: 1, b: 2})` yields `['-a=1', '-b=2']` */

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -5,7 +5,7 @@ import child_process from 'node:child_process';
 import events from 'node:events';
 import path from 'node:path';
 import https from 'node:https';
-import { pipeline } from 'node:stream/promises';
+import stream from 'node:stream/promises';
 
 async function parseArguments() {
   const jsonImport = {
@@ -169,7 +169,7 @@ if (!args.build) {
   const [response] = await events.once(https.get(downloadURL), 'response');
 
   const start = performance.now();
-  await pipeline(response, unzip.stdin);
+  await stream.pipeline(response, unzip.stdin);
   const end = performance.now();
 
   console.error(`downloaded libmongocrypt in ${(end - start) / 1000} secs...`);

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -59,6 +59,7 @@ async function run(command, args = [], options = {}) {
   const commandDetails = `+ ${command} ${args.join(' ')}${options.cwd ? ` (in: ${options.cwd})` : ''}`;
   console.error(commandDetails);
   const proc = child_process.spawn(command, args, {
+    shell: process.platform === 'win32',
     stdio: 'inherit',
     cwd: resolveRoot('.'),
     ...options
@@ -171,9 +172,12 @@ export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
 
   console.error(`Platform: ${detectedPlatform} Prebuild: ${prebuild}`);
 
-  const unzipArgs = ['-xzv', '-C', destination, `${prebuild}/nocrypto`];
+  const unzipArgs = ['-xzv', '-C', `_libmongocrypt-${ref}`, `${prebuild}/nocrypto`];
   console.error(`+ tar ${unzipArgs.join(' ')}`);
-  const unzip = child_process.spawn('tar', unzipArgs, { stdio: ['pipe', 'inherit'] });
+  const unzip = child_process.spawn('tar', unzipArgs, {
+    stdio: ['pipe', 'inherit'],
+    cwd: resolveRoot('.')
+  });
 
   const [response] = await events.once(https.get(downloadURL), 'response');
 
@@ -228,7 +232,7 @@ async function main() {
   // install with "ignore-scripts" so that we don't attempt to download a prebuild
   await run('npm', ['install', '--ignore-scripts']);
   // The prebuild command will make both a .node file in `./build` (local and CI testing will run on current code)
-  // it will also produce `./prebuild/xx.tgz`. prebuild has GH upload functionality.
+  // it will also produce `./prebuilds/mongodb-client-encryption-vVERSION-napi-vNAPI_VERSION-OS-ARCH.tar.gz`.
   await run('npm', ['run', 'prebuild']);
 }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,16 @@ jobs:
           node: ['20.x'] # '16.x', '18.x',
     name: Node.js ${{ matrix.node }} build
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
       - run: npm install -g npm@latest
         shell: bash
+
       - run: node .github/scripts/libmongocrypt.mjs
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,23 +8,74 @@ on:
 name: build
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  host_builds:
     strategy:
-        matrix:
-          node: ['20.x'] # '16.x', '18.x',
-    name: Node.js ${{ matrix.node }} build
+      matrix:
+        os: [macos-11, macos-latest, windows-2019]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Build ${{ matrix.os }} Prebuild
+        run: node .github/scripts/libmongocrypt.mjs ${{ runner.os == 'Windows' && '--build' || '' }}
+        shell: bash
+
+      - id: upload
+        name: Upload prebuild
+        uses: actions/upload-artifact@v4
         with:
-          node-version: ${{ matrix.node }}
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          name: build-${{ matrix.os }}
+          path: prebuilds/
+          if-no-files-found: 'error'
+          retention-days: 1
+          compression-level: 0
 
-      - run: npm install -g npm@latest
-        shell: bash
+  container_builds:
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        linux_arch: [s390x, arm64, amd64]
+    steps:
+      - uses: actions/checkout@v4
 
-      - run: node .github/scripts/libmongocrypt.mjs
-        shell: bash
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run Buildx
+        run: |
+          docker buildx create --name builder --bootstrap --use
+          docker buildx build --platform linux/${{ matrix.linux_arch }} --output type=local,dest=./prebuilds,platform-split=false -f ./.github/docker/Dockerfile.glibc .
+
+      - id: upload
+        name: Upload prebuild
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-linux-${{ matrix.linux_arch }}
+          path: prebuilds/
+          if-no-files-found: 'error'
+          retention-days: 1
+          compression-level: 0
+
+  collect:
+    needs: [host_builds, container_builds]
+    runs-on: ubunutu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - id: upload
+        name: Upload all prebuilds
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-build
+          path: '*.tar.gz'
+          if-no-files-found: 'error'
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 on:
   push:
     branches: [main]
+  pull_request:
+      branches: [main]
   workflow_dispatch: {}
 
 name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches: [main]
   pull_request:
-      branches: [main]
+    branches: [main]
   workflow_dispatch: {}
 
 name: build

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ xunit.xml
 lib
 prebuilds
 
-_libmongocrypt/
+_libmongocrypt*

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "check:clang-format": "clang-format --style=file:.clang-format --dry-run --Werror addon/*",
     "test": "mocha test",
     "prepare": "tsc",
-    "rebuild": "prebuild --compile",
     "prebuild": "prebuild --runtime napi --strip --verbose --all"
   },
   "author": {


### PR DESCRIPTION
### Description

#### What is changing?

- We now download a prebuild of libmongocrypt instead of building from source.
- `--build`, `-b` will still build from source

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Now we do not need to have cmake or other toolchain requirements satisfied for libmongocrypt only what is needed for the bindings.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
