### PR TITLE
fix(NODE-6173): add rangeV2 feature flag toggle to Node.js bindings

### DIFF
--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -514,6 +514,10 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info)
         mongocrypt_setopt_bypass_query_analysis(_mongo_crypt.get());
     }
 
+    if (options.Get("rangeV2").ToBoolean()) {
+        mongocrypt_setopt_use_range_v2(_mongo_crypt.get());
+    }
+
     mongocrypt_setopt_use_need_kms_credentials_state(_mongo_crypt.get());
 
     // Initialize after all options are set.

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ export interface MongoCryptConstructor {
     cryptSharedLibSearchPaths?: string[];
     cryptSharedLibPath?: string;
     bypassQueryAnalysis?: boolean;
+    /** @experimental */
+    rangeV2?: boolean;
   }): MongoCrypt;
   libmongocryptVersion: string;
 }


### PR DESCRIPTION
### Description

#### What is changing?

See the ticket for motivation/why it would be convenient to have this earlier than the 'main' range V2 work 🙂 

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Testing

Porting change from: https://github.com/mongodb/libmongocrypt/pull/809

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Adds an internal flag to enable `rangeV2`

A new option `rangeV2` can be passed to the MongoCrypt constructor to enable the new protocol. It is marked expiremental because it will likely be removed in a future release, this is for testing only.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
