### PR TITLE
chore(NODE-6160): sign and upload to releases

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,15 @@
+name: Setup
+description: 'Installs node, driver dependencies, and builds source'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install -g npm@latest
+      shell: bash
+    - run: npm clean-install --ignore-scripts
+      shell: bash

--- a/.github/actions/sign_and_upload_package/action.yml
+++ b/.github/actions/sign_and_upload_package/action.yml
@@ -1,0 +1,71 @@
+name: Sign and Upload Package
+description: 'Signs native modules with garasign'
+
+inputs: 
+    aws_role_arn:
+      description: 'AWS role input for drivers-github-tools/gpg-sign@v2'
+      required: true
+    aws_region_name:
+      description: 'AWS region name input for drivers-github-tools/gpg-sign@v2'
+      required: true
+    aws_secret_id:
+      description: 'AWS secret id input for drivers-github-tools/gpg-sign@v2'
+      required: true
+    npm_package_name:
+      description: 'The name for the npm package this repository represents'
+      required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v4
+
+    - name: Make signatures directory
+      shell: bash
+      run: mkdir artifacts
+
+    - name: Set up drivers-github-tools
+      uses: mongodb-labs/drivers-github-tools/setup@v2
+      with: 
+        aws_region_name: ${{ inputs.aws_region_name }}
+        aws_role_arn: ${{ inputs.aws_role_arn }}
+        aws_secret_id: ${{ inputs.aws_secret_id }}
+
+    - name: Create detached signature
+      uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
+      with: 
+        filenames: 'build-*/*.tar.gz'
+      env: 
+        RELEASE_ASSETS: artifacts/
+
+    - name: Copy the tarballs to the artifacts directory
+      shell: bash
+      run: for filename in build-*/*.tar.gz; do cp ${filename} artifacts/; done
+
+    - run: npm pack
+      shell: bash
+
+    - name: Get release version and release package file name
+      id: get_vars
+      shell: bash
+      run: |
+        package_version=$(jq --raw-output '.version' package.json)
+        echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+        echo "package_file=${{ inputs.npm_package_name }}-${package_version}.tgz" >> "$GITHUB_OUTPUT"
+
+    - name: Create detached signature for module
+      uses: mongodb-labs/drivers-github-tools/gpg-sign@v2
+      with: 
+        filenames: ${{ steps.get_vars.outputs.package_file }}
+      env: 
+        RELEASE_ASSETS: artifacts/
+
+    - name: Display structure of downloaded files
+      shell: bash
+      run: ls -la artifacts/
+
+    - name: "Upload release artifacts"
+      run: gh release upload v${{ steps.get_vars.outputs.package_version }} artifacts/*.*
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/sign_and_upload_package/action.yml
+++ b/.github/actions/sign_and_upload_package/action.yml
@@ -64,8 +64,8 @@ runs:
       shell: bash
       run: ls -la artifacts/
 
-    # - name: "Upload release artifacts"
-    #   run: gh release upload v${{ steps.get_vars.outputs.package_version }} artifacts/*.*
-    #   shell: bash
-    #   env:
-    #     GH_TOKEN: ${{ github.token }}
+    - name: "Upload release artifacts"
+      run: gh release upload v${{ steps.get_vars.outputs.package_version }} artifacts/*.*
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/actions/sign_and_upload_package/action.yml
+++ b/.github/actions/sign_and_upload_package/action.yml
@@ -64,8 +64,8 @@ runs:
       shell: bash
       run: ls -la artifacts/
 
-    - name: "Upload release artifacts"
-      run: gh release upload v${{ steps.get_vars.outputs.package_version }} artifacts/*.*
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
+    # - name: "Upload release artifacts"
+    #   run: gh release upload v${{ steps.get_vars.outputs.package_version }} artifacts/*.*
+    #   shell: bash
+    #   env:
+    #     GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,8 @@ jobs:
         uses: googleapis/release-please-action@v4
 
   sign_and_upload:
-    needs: [host_builds, container_builds]
-    # needs: [release_please]
-    # if: ${{ needs.release_please.outputs.release_created }}
+    needs: [release_please]
+    if: ${{ needs.release_please.outputs.release_created }}
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -96,6 +95,6 @@ jobs:
           aws_region_name: 'us-east-1'
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           npm_package_name: 'mongodb-client-encryption'
-      # - run: npm publish --provenance
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
 
 name: Build and Test
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   host_builds:
     strategy:
@@ -65,21 +70,31 @@ jobs:
           retention-days: 1
           compression-level: 0
 
-  collect:
+  release_please:
     needs: [host_builds, container_builds]
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: actions/download-artifact@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
 
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - id: upload
-        name: Upload all prebuilds
-        uses: actions/upload-artifact@v4
-        with:
-          name: all-build
-          path: '*.tar.gz'
-          if-no-files-found: 'error'
-          retention-days: 1
-          compression-level: 0
+  sign_and_upload:
+    needs: [release_please]
+    if: ${{ needs.release_please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+      - name: actions/setup
+        uses: ./.github/actions/setup
+      - name: actions/sign_and_upload_package
+        uses: ./.github/actions/sign_and_upload_package
+        with: 
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: 'us-east-1'
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
+          npm_package_name: 'mongodb-client-encryption'
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,9 @@ jobs:
         uses: googleapis/release-please-action@v4
 
   sign_and_upload:
-    needs: [release_please]
-    if: ${{ needs.release_please.outputs.release_created }}
+    needs: [host_builds, container_builds]
+    # needs: [release_please]
+    # if: ${{ needs.release_please.outputs.release_created }}
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -95,6 +96,6 @@ jobs:
           aws_region_name: 'us-east-1'
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           npm_package_name: 'mongodb-client-encryption'
-      - run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - run: npm publish --provenance
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description

#### What is changing?
- Adds signing to the native bundle tarballs and uploads them to the Github release.
- Uploads the detached signatures for the tarballs to the Github release.
- Adds release please to the Github apps builds.
- Publishes the release with provenance.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6160

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
