### PR TITLE
chore: remove unused `exists` function

### DIFF
--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -15,15 +15,6 @@ function resolveRoot(...paths) {
   return path.resolve(__dirname, '..', '..', ...paths);
 }
 
-async function exists(fsPath) {
-  try {
-    await fs.access(fsPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function parseArguments() {
   const pkg = JSON.parse(await fs.readFile(resolveRoot('package.json'), 'utf8'));
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
   collect:
     needs: [host_builds, container_builds]
-    runs-on: ubunutu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
 


### PR DESCRIPTION
### Description

#### What is changing?

- remove exists function

##### Is there new documentation needed for these changes?

no

#### What is the motivation for this change?

Checking if something exists before doing a FS action on it risks race condition. 

We don't use exists and we shouldn't add it back in. cleanup.

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
