### PR TITLE
feat(NODE-5908): support range v2 protocol

### DIFF
--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -514,9 +514,7 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info)
         mongocrypt_setopt_bypass_query_analysis(_mongo_crypt.get());
     }
 
-    if (options.Get("rangeV2").ToBoolean()) {
-        mongocrypt_setopt_use_range_v2(_mongo_crypt.get());
-    }
+    mongocrypt_setopt_use_range_v2(_mongo_crypt.get());
 
     mongocrypt_setopt_use_need_kms_credentials_state(_mongo_crypt.get());
 

--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -596,10 +596,10 @@ Value MongoCrypt::MakeExplicitEncryptionContext(const CallbackInfo& info) {
             throw TypeError::New(Env(), errorStringFromStatus(context.get()));
         }
 
-        if (strcasecmp(algorithm.c_str(), "rangepreview") == 0) {
+        if (strcasecmp(algorithm.c_str(), "range") == 0) {
             if (!options.Has("rangeOptions")) {
                 throw TypeError::New(
-                    Env(), "`rangeOptions` must be provided if `algorithm` is set to RangePreview");
+                    Env(), "`rangeOptions` must be provided if `algorithm` is set to Range");
             }
 
             Uint8Array rangeOptions = Uint8ArrayFromValue(options["rangeOptions"], "rangeOptions");

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,6 @@ export interface MongoCryptConstructor {
     cryptSharedLibSearchPaths?: string[];
     cryptSharedLibPath?: string;
     bypassQueryAnalysis?: boolean;
-    /** @experimental */
-    rangeV2?: boolean;
   }): MongoCrypt;
   libmongocryptVersion: string;
 }

--- a/test/bindings.test.ts
+++ b/test/bindings.test.ts
@@ -341,17 +341,17 @@ describe('MongoCryptConstructor', () => {
       });
     });
 
-    context('when algorithm is `rangePreview', () => {
+    context('when algorithm is `Range', () => {
       it('throws a TypeError if rangeOptions is not provided', () => {
         expect(() =>
           mc.makeExplicitEncryptionContext(value, {
             // minimum required arguments from libmongocrypt
             keyId: keyId.buffer,
             expressionMode: false,
-            algorithm: 'rangePreview'
+            algorithm: 'Range'
           })
         )
-          .to.throw(/`rangeOptions` must be provided if `algorithm` is set to RangePreview/)
+          .to.throw(/`rangeOptions` must be provided if `algorithm` is set to Range/)
           .to.be.instanceOf(TypeError);
       });
 
@@ -361,7 +361,7 @@ describe('MongoCryptConstructor', () => {
             // minimum required arguments from libmongocrypt
             keyId: keyId.buffer,
             expressionMode: false,
-            algorithm: 'rangePreview',
+            algorithm: 'Range',
             rangeOptions: 'non-buffer'
           })
         )
@@ -369,18 +369,18 @@ describe('MongoCryptConstructor', () => {
           .to.be.instanceOf(TypeError);
       });
 
-      it('checks if `rangePreview` is set case-insensitive', () => {
+      it('checks if `Range` is set case-insensitive', () => {
         expect(
           mc.makeExplicitEncryptionContext(value, {
             // minimum required arguments from libmongocrypt
             keyId: keyId.buffer,
             expressionMode: false,
-            algorithm: 'RANGEPREVIEW',
+            algorithm: 'RANGE',
             rangeOptions: serialize({
               sparsity: new Long(42)
             }),
 
-            // contention factor is required for `rangePreview` but
+            // contention factor is required for `Range` but
             // is enforced in libmongocrypt, not our bindings
             contentionFactor: 2
           })


### PR DESCRIPTION
### Description

#### What is changing?

All references to `rangepreview` have been renamed to `range`.  Additionally, the feature flag for range v2 has been removed (confirmed with Kenn that supporint v1 is no longer necessary).

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
