### PR TITLE
chore: prepare for alpha release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,11 @@ jobs:
         uses: ./.github/actions/setup
       - name: actions/sign_and_upload_package
         uses: ./.github/actions/sign_and_upload_package
-        with: 
+        with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: 'us-east-1'
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           npm_package_name: 'mongodb-client-encryption'
-      - run: npm publish --provenance
+      - run: npm publish --provenance --tag=alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,8 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": true,
       "prerelease-type": "alpha",
+      "prerelease": true,
       "versioning": "prerelease"
     }
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,9 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": true,
+      "prerelease-type": "alpha",
+      "versioning": "prerelease"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
### Description

#### What is changing?

- Changing configurations so the next release is an alpha

##### Is there new documentation needed for these changes?

Not here, will update the release documentation in the driver.

- https://github.com/mongodb/node-mongodb-native/blob/main/etc/notes/releasing.md

#### What is the motivation for this change?

Testing automated releases with a prerelease

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
