### PR TITLE
feat(NODE-6226): build macos universal binary

### DIFF
--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -41,7 +41,8 @@ async function parseArguments() {
   return {
     libmongocrypt: { url: args.values.gitURL, ref: args.values.libVersion },
     clean: args.values.clean,
-    build: args.values.build
+    build: args.values.build,
+    pkg
   };
 }
 
@@ -189,7 +190,7 @@ export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
 }
 
 async function main() {
-  const { libmongocrypt, build, clean } = await parseArguments();
+  const { libmongocrypt, build, clean, pkg } = await parseArguments();
 
   const nodeDepsDir = resolveRoot('deps');
 
@@ -228,6 +229,14 @@ async function main() {
   // The prebuild command will make both a .node file in `./build` (local and CI testing will run on current code)
   // it will also produce `./prebuilds/mongodb-client-encryption-vVERSION-napi-vNAPI_VERSION-OS-ARCH.tar.gz`.
   await run('npm', ['run', 'prebuild']);
+
+  if (process.platform === 'darwin') {
+    // The "arm64" build is actually a universal binary
+    await fs.copyFile(
+      `prebuilds/mongodb-client-encryption-v${pkg.version}-napi-v4-darwin-arm64.tar.gz`,
+      `prebuilds/mongodb-client-encryption-v${pkg.version}-napi-v4-darwin-x64.tar.gz`
+    );
+  }
 }
 
 await main();

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -233,8 +233,8 @@ async function main() {
   if (process.platform === 'darwin') {
     // The "arm64" build is actually a universal binary
     await fs.copyFile(
-      `prebuilds/mongodb-client-encryption-v${pkg.version}-napi-v4-darwin-arm64.tar.gz`,
-      `prebuilds/mongodb-client-encryption-v${pkg.version}-napi-v4-darwin-x64.tar.gz`
+      resolveRoot('prebuilds', `mongodb-client-encryption-v${pkg.version}-napi-v4-darwin-arm64.tar.gz`),
+      resolveRoot('prebuilds', `mongodb-client-encryption-v${pkg.version}-napi-v4-darwin-x64.tar.gz`)
     );
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   host_builds:
     strategy:
       matrix:
-        os: [macos-11, macos-latest, windows-2019]
+        os: [macos-latest, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Run the following command to build libmongocrypt and setup the node bindings for
 bash ./etc/build-static.sh
 ```
 
+#### Prebuild Platforms
+
+Below are the platforms that are available as prebuilds on each github release.
+`prebuild-install` downloads these automatically depending on the platform you are running npm install on.
+
+- Linux GLIBC 2.23 or later
+    - s390x
+    - arm64
+    - x64
+- MacOS universal binary
+    - x64
+    - arm64
+- Windows
+    - x64
+
 #### Linting
 
 We lint both the c++ bindings and the Typescript.

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,7 +23,15 @@
     'xcode_settings': {
       'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
       'CLANG_CXX_LIBRARY': 'libc++',
-      'MACOSX_DEPLOYMENT_TARGET': '10.12'
+      'MACOSX_DEPLOYMENT_TARGET': '10.12',
+      "OTHER_CFLAGS": [
+        "-arch x86_64",
+        "-arch arm64"
+      ],
+      "OTHER_LDFLAGS": [
+        "-arch x86_64",
+        "-arch arm64"
+      ]
     },
     'cflags!': [ '-fno-exceptions' ],
     'cflags_cc!': [ '-fno-exceptions' ],


### PR DESCRIPTION
### Description

#### What is changing?

- We build one universal binary on macos-latest
- Copy the tar file to have an x64 name for prebuild's sake

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Stop using macos 11 because it will be removed soon

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
