### PR TITLE
chore: add typescript compilation to build script

### DIFF
--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -229,6 +229,8 @@ async function main() {
   // The prebuild command will make both a .node file in `./build` (local and CI testing will run on current code)
   // it will also produce `./prebuilds/mongodb-client-encryption-vVERSION-napi-vNAPI_VERSION-OS-ARCH.tar.gz`.
   await run('npm', ['run', 'prebuild']);
+  // Compile Typescript
+  await run('npm', ['run', 'prepare']);
 
   if (process.platform === 'darwin') {
     // The "arm64" build is actually a universal binary


### PR DESCRIPTION
### Description

#### What is changing?

- Build typescript at the end of building the bindings

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

The build script runs npm install like so:
```js
await run('npm', ['install', '--ignore-scripts']);
```
creates a prebuild, then finishes.

Because of `'--ignore-scripts'` it doesn't run the prepare lifecycle hook, so typescript isn't compiled. 

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
