### PR TITLE
fix(MONGOSH-1808): static building on intel macs and windows

### DIFF
--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -140,10 +140,10 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   await run(
     options.cMakePath,
     [...CMAKE_FLAGS, ...WINDOWS_CMAKE_FLAGS, ...DARWIN_CMAKE_FLAGS, libmongocryptRoot],
-    { cwd: nodeBuildRoot }
+    { cwd: nodeBuildRoot, shell: process.platform === 'win32' }
   );
   await run(options.cMakePath, ['--build', '.', '--target', 'install', '--config', 'RelWithDebInfo'], {
-    cwd: nodeBuildRoot
+    cwd: nodeBuildRoot, shell: process.platform === 'win32'
   });
 }
 

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -125,7 +125,7 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
     /**
      * Where to install libmongocrypt
      * Note that `binding.gyp` will set `./deps/include`
-     * as an include path if BUILD_TYPE=static
+     * as an include path if libmongocrypt_link_type=static
      */
     DCMAKE_INSTALL_PREFIX: nodeDepsRoot
   });
@@ -286,7 +286,7 @@ async function main() {
   }
 
   if (args.dynamic) {
-    gypDefines.push({ build_type: 'dynamic' });
+    gypDefines.push({ libmongocrypt_link_type: 'dynamic' });
   }
 
   const prebuildOptions =

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Can be configured to clone and build without crypto.
                         You may use "latest" to get current libmongocrypt `HEAD`.
 --clean                 Combined with --build, the script will not skip cloning and rebuilding libmongocrypt.
 --build                 Instead of downloading, clone and build libmongocrypt along with the bindings.
---no-macos-universal    Disable creating a universal binary for MacOS builds.
 --dynamic               Skips cloning or downloading libmongocrypt, runs prebuild with build_type set to "dynamic" to compile
                         a prebuild that links to a system copy of libmongocrypt.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm run install:libmongocrypt
 #### `libmongocrypt.mjs`
 
 ```
-node libmongocrypt.mjs [--gitURL=string] [--libVersion=string] [--clean] [--build] [--no-crypto] [--fastDownload]
+node libmongocrypt.mjs [optional flags]
 
 By default attempts to download and compile the bindings with the crypto prebuilds of libmongocrypt.
 Can be configured to clone and build without crypto.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Can be configured to clone and build without crypto.
 --clean                 Combined with --build, the script will not skip cloning and rebuilding libmongocrypt.
 --build                 Instead of downloading, clone and build libmongocrypt along with the bindings.
 --no-macos-universal    Disable creating a universal binary for MacOS builds.
+--dynamic               Skips cloning or downloading libmongocrypt, runs prebuild with build_type set to "dynamic" to compile
+                        a prebuild that links to a system copy of libmongocrypt.
 
 Only suitable for local development:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Can be configured to clone and build without crypto.
 --build                 Instead of downloading, clone and build libmongocrypt along with the bindings.
 --dynamic               Skips cloning or downloading libmongocrypt, runs prebuild with build_type set to "dynamic" to compile
                         a prebuild that links to a system copy of libmongocrypt.
+--skip-bindings         Skips running prebuild. Useful if only the libmongocrypt dependency is desired.
 
 Only suitable for local development:
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Can be configured to clone and build without crypto.
                         You may use "latest" to get current libmongocrypt `HEAD`.
 --clean                 Combined with --build, the script will not skip cloning and rebuilding libmongocrypt.
 --build                 Instead of downloading, clone and build libmongocrypt along with the bindings.
+--no-macos-universal    Disable creating a universal binary for MacOS builds.
 
 Only suitable for local development:
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,18 +5,9 @@
         "<!(node -p \"require('node-addon-api').include_dir\")",
     ],
     'variables': {
-        'ARCH': '<(host_arch)',
-        'variables': {
-            'build_type%': "dynamic",
-        },
-        'conditions': [
-          ['OS=="win"', {
-            'build_type' : "<!(echo %BUILD_TYPE%)"
-          }],
-          ['OS!="win"', {
-            'build_type' : "<!(echo $BUILD_TYPE)",
-          }]
-        ]
+      'ARCH': '<(host_arch)',
+      'no_macos_universal%': 'false',
+      'build_type%': 'dynamic',
     },
     'sources': [
       'addon/mongocrypt.cc'
@@ -38,7 +29,7 @@
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
       }],
-      ['OS=="mac" and ARCH=="arm64"', {
+      ['OS=="mac" and ARCH=="arm64" and "<(no_macos_universal)"!="true"', {
           'xcode_settings': {
             "OTHER_CFLAGS": [
               "-arch x86_64",

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,13 +1,13 @@
 {
   'targets': [{
     'target_name': 'mongocrypt',
+    'type': 'loadable_module',
     'include_dirs': [
         "<!(node -p \"require('node-addon-api').include_dir\")",
     ],
     'variables': {
       'ARCH': '<(host_arch)',
-      'no_macos_universal%': 'false',
-      'build_type%': 'static',
+      'libmongocrypt_link_type%': 'static',
     },
     'sources': [
       'addon/mongocrypt.cc'
@@ -16,6 +16,7 @@
       'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
       'CLANG_CXX_LIBRARY': 'libc++',
       'MACOSX_DEPLOYMENT_TARGET': '10.12',
+      'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
     },
     'cflags!': [ '-fno-exceptions' ],
     'cflags_cc!': [ '-fno-exceptions' ],
@@ -23,13 +24,8 @@
       'VCCLCompilerTool': { 'ExceptionHandling': 1 },
     },
     'conditions': [
-      ['OS=="mac"', {
-          'cflags+': ['-fvisibility=hidden'],
-          'xcode_settings': {
-            'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
-          }
-      }],
-      ['OS=="mac" and ARCH=="arm64" and "<(no_macos_universal)"!="true"', {
+      ['OS=="mac"', { 'cflags+': ['-fvisibility=hidden'] }],
+      ['_type!="static_library"', {
           'xcode_settings': {
             "OTHER_CFLAGS": [
               "-arch x86_64",
@@ -41,14 +37,10 @@
             ]
           }
       }],
-      ['build_type=="dynamic"', {
-        'link_settings': {
-          'libraries': [
-            '-lmongocrypt'
-          ]
-        }
+      ['libmongocrypt_link_type=="dynamic"', {
+        'link_settings': { 'libraries': ['-lmongocrypt'] }
       }],
-      ['build_type!="dynamic"', {
+      ['libmongocrypt_link_type!="dynamic"', {
         'conditions': [
           ['OS!="win"', {
             'include_dirs': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -25,7 +25,7 @@
     },
     'conditions': [
       ['OS=="mac"', { 'cflags+': ['-fvisibility=hidden'] }],
-      ['_type!="static_library"', {
+      ['_type!="static_library" and ARCH=="arm64"', {
           'xcode_settings': {
             "OTHER_CFLAGS": [
               "-arch x86_64",
@@ -40,7 +40,7 @@
       ['libmongocrypt_link_type=="dynamic"', {
         'link_settings': { 'libraries': ['-lmongocrypt'] }
       }],
-      ['libmongocrypt_link_type!="dynamic"', {
+      ['libmongocrypt_link_type=="static"', {
         'conditions': [
           ['OS!="win"', {
             'include_dirs': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
     'variables': {
       'ARCH': '<(host_arch)',
       'no_macos_universal%': 'false',
-      'build_type%': 'dynamic',
+      'build_type%': 'static',
     },
     'sources': [
       'addon/mongocrypt.cc'

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,7 @@
         "<!(node -p \"require('node-addon-api').include_dir\")",
     ],
     'variables': {
+        'ARCH': '<(host_arch)',
         'variables': {
             'build_type%': "dynamic",
         },
@@ -24,14 +25,6 @@
       'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
       'CLANG_CXX_LIBRARY': 'libc++',
       'MACOSX_DEPLOYMENT_TARGET': '10.12',
-      "OTHER_CFLAGS": [
-        "-arch x86_64",
-        "-arch arm64"
-      ],
-      "OTHER_LDFLAGS": [
-        "-arch x86_64",
-        "-arch arm64"
-      ]
     },
     'cflags!': [ '-fno-exceptions' ],
     'cflags_cc!': [ '-fno-exceptions' ],
@@ -43,6 +36,18 @@
           'cflags+': ['-fvisibility=hidden'],
           'xcode_settings': {
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
+          }
+      }],
+      ['OS=="mac" and ARCH=="arm64"', {
+          'xcode_settings': {
+            "OTHER_CFLAGS": [
+              "-arch x86_64",
+              "-arch arm64"
+            ],
+            "OTHER_LDFLAGS": [
+              "-arch x86_64",
+              "-arch arm64"
+            ]
           }
       }],
       ['build_type=="dynamic"', {


### PR DESCRIPTION
### Description

#### What is changing?

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fixes macos flags for static build

When building a static library version of this package we omit the arch flags since you only need to build for your current system.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
