### PR TITLE
chore: compile linux builds with GLIBC 2.28

### DIFF
--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -1,4 +1,4 @@
-ARG NODE_BUILD_IMAGE=node:16.20.1-bullseye
+ARG NODE_BUILD_IMAGE=node:16.20.1-buster
 FROM $NODE_BUILD_IMAGE AS build
 
 WORKDIR /mongodb-client-encryption

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -232,6 +232,9 @@ async function main() {
   const { pkg, ...args } = await parseArguments();
   console.log(args);
 
+  // GLIBC information
+  if (process.platform === 'linux') await run('ldd', ['--version']);
+
   const nodeDepsDir = resolveRoot('deps');
 
   if (args.build) {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Only suitable for local development:
 Below are the platforms that are available as prebuilds on each github release.
 `prebuild-install` downloads these automatically depending on the platform you are running npm install on.
 
-- Linux GLIBC 2.23 or later
+- Linux GLIBC 2.28 or later
     - s390x
     - arm64
     - x64


### PR DESCRIPTION
### Description

#### What is changing?

- buster comes with glibc 2.28

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Remain compatible with RHEL 8

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
