### PR TITLE
fix(NODE-6237): build against glibc 2.27

### DIFF
--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -1,11 +1,17 @@
-ARG NODE_BUILD_IMAGE=node:16.20.1-bullseye
-FROM $NODE_BUILD_IMAGE AS build
+FROM ubuntu:bionic AS build
+
+# Possible values: s390x, arm64, x64
+ARG NODE_ARCH
+ADD https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-${NODE_ARCH}.tar.gz /
+RUN mkdir -p /nodejs && tar -xzf /node-v16.20.1-linux-${NODE_ARCH}.tar.gz --strip-components=1 -C /nodejs
+ENV PATH=$PATH:/nodejs/bin
 
 WORKDIR /mongodb-client-encryption
 COPY . .
 
-RUN npm run install:libmongocrypt
-RUN npm run test
+RUN apt-get -qq update && apt-get -qq install -y python3 build-essential && ldd --version
+
+RUN npm run install:libmongocrypt && npm run test
 
 FROM scratch
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run Buildx
         run: |
           docker buildx create --name builder --bootstrap --use
-          docker buildx build --platform linux/${{ matrix.linux_arch }} --output type=local,dest=./prebuilds,platform-split=false -f ./.github/docker/Dockerfile.glibc .
+          docker buildx build --platform linux/${{ matrix.linux_arch }} --build-arg NODE_ARCH=${{ matrix.linux_arch == 'amd64' && 'x64' || matrix.linux_arch }} --output type=local,dest=./prebuilds,platform-split=false -f ./.github/docker/Dockerfile.glibc .
 
       - id: upload
         name: Upload prebuild

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,16 +17,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 'lts/*'
         cache: 'npm'
+
     - name: "Build libmongocrypt"
       shell: bash
       run: |
         npm run install:libmongocrypt
-        
+
     - if: matrix.lint-target == 'c++'
       shell: bash
       run: |

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -22,7 +22,7 @@ const REQUIRED_FILES = [
 ];
 
 describe(`Release ${packFile}`, function () {
-  this.timeout(10000);
+  this.timeout(60000);
 
   beforeEach(function () {
     if (process.arch !== 'x64') {


### PR DESCRIPTION
### Description

#### What is changing?

- Change linux build OS to ubunut bionic making glibc requirement 2.27+

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Compatibility with RHEL 8

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
