### PR TITLE
chore: prepare for non-prerelease

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,34 +68,3 @@ jobs:
           if-no-files-found: 'error'
           retention-days: 1
           compression-level: 0
-
-  release_please:
-    needs: [host_builds, container_builds]
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-    steps:
-      - id: release
-        uses: googleapis/release-please-action@v4
-
-  sign_and_upload:
-    needs: [release_please]
-    if: ${{ needs.release_please.outputs.release_created }}
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Node and dependencies
-        uses: mongodb-labs/drivers-github-tools/node/setup@v2
-        with:
-          ignore_install_scripts: true
-      - name: actions/sign_and_upload_package
-        uses: ./.github/actions/sign_and_upload_package
-        with:
-          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws_region_name: 'us-east-1'
-          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
-          npm_package_name: 'mongodb-client-encryption'
-      - run: npm publish --provenance --tag=alpha
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_6.1.yml
+++ b/.github/workflows/release_6.1.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           ignore_install_scripts: true
 
-      - run: npm publish --provenance --tag=alpha
+      - run: npm publish --provenance
         if: ${{ needs.release_please.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
       "release-type": "node",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": true
+      "draft": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
### Description

#### What is changing?

- Remove releasing from pull_request workflow
- Remove prerelease from config, do not tag npm package with alpha

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

Proper release incoming :rocket:

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
