### PR TITLE
fix(NODE-6300): make expressionMode required in C++ in makeExplicitEncryptionContext

### DIFF
--- a/addon/mongocrypt.h
+++ b/addon/mongocrypt.h
@@ -56,6 +56,8 @@ namespace opensslcrypto {
 std::unique_ptr<CryptoHooks> createOpenSSLCryptoHooks();
 }
 
+typedef bool (*ExplicitEncryptionContextInitFunction)(mongocrypt_ctx_t*, mongocrypt_binary_t*);
+
 class MongoCrypt : public Napi::ObjectWrap<MongoCrypt> {
    public:
     static Napi::Function Init(Napi::Env env);
@@ -67,6 +69,9 @@ class MongoCrypt : public Napi::ObjectWrap<MongoCrypt> {
     Napi::Value MakeExplicitDecryptionContext(const Napi::CallbackInfo& info);
     Napi::Value MakeDataKeyContext(const Napi::CallbackInfo& info);
     Napi::Value MakeRewrapManyDataKeyContext(const Napi::CallbackInfo& info);
+    Napi::Value MakeExplicitEncryptionContextInternal(ExplicitEncryptionContextInitFunction init_fn,
+                                                      const Napi::Uint8Array& value,
+                                                      const Napi::Object& options);
 
     Napi::Value Status(const Napi::CallbackInfo& info);
     Napi::Value CryptSharedLibVersionInfo(const Napi::CallbackInfo& info);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check:clang-format": "clang-format --style=file:.clang-format --dry-run --Werror addon/*",
     "test": "mocha test",
     "prepare": "tsc",
+    "rebuild": "node-gyp rebuild",
     "prebuild": "prebuild --runtime napi --strip --verbose --all"
   },
   "author": {

--- a/test/bindings.test.ts
+++ b/test/bindings.test.ts
@@ -387,6 +387,20 @@ describe('MongoCryptConstructor', () => {
         ).to.be.instanceOf(MongoCryptContextCtor);
       });
     });
+
+    describe('options.expressionMode', function () {
+      it('throws if `expressionMode` is not defined', function () {
+        expect(() =>
+          mc.makeExplicitEncryptionContext(value, {
+            // minimum required arguments from libmongocrypt
+            keyId: keyId.buffer,
+            algorithm: 'Unindexed'
+          })
+        )
+          .to.throw(/option `expressionMode` is required./)
+          .to.be.instanceOf(TypeError);
+      });
+    });
   });
 });
 

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -38,7 +38,8 @@ function createEncryptedDocument(mongoCrypt: MongoCrypt) {
 
   const ctx = mongoCrypt.makeExplicitEncryptionContext(BSON.serialize({ v }), {
     keyId: keyId.buffer,
-    algorithm
+    algorithm,
+    expressionMode: false
   });
 
   const getState = () => ctx.state;
@@ -85,7 +86,7 @@ describe('Crypto hooks', () => {
 
       const mongoCryptOptions: ConstructorParameters<MongoCryptConstructor>[0] = {
         kmsProviders: BSON.serialize(kmsProviders),
-        cryptoCallbacks: spiedCallbacks
+        cryptoCallbacks: spiedCallbacks,
       };
 
       const mongoCrypt = new MongoCrypt(mongoCryptOptions);

--- a/test/crypto.test.ts
+++ b/test/crypto.test.ts
@@ -86,7 +86,7 @@ describe('Crypto hooks', () => {
 
       const mongoCryptOptions: ConstructorParameters<MongoCryptConstructor>[0] = {
         kmsProviders: BSON.serialize(kmsProviders),
-        cryptoCallbacks: spiedCallbacks,
+        cryptoCallbacks: spiedCallbacks
       };
 
       const mongoCrypt = new MongoCrypt(mongoCryptOptions);


### PR DESCRIPTION
### Description

#### What is changing?

MakeExplicitEncryptionContext takes an option, `expressionMode`, that controls whether an expression context or regular context is instantiated.  This option is always provided by the driver, is required by TS but in C++ we coerce the option to boolean instead.

This PR aligns the C++ to match the intended behavior.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
