### PR TITLE
feat(NODE-6307): use libmongocrypt 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.10.0",
+  "mongodb:libmongocrypt": "1.11.0",
   "dependencies": {
     "bindings": "^1.5.0",
     "node-addon-api": "^4.3.0",


### PR DESCRIPTION
### Description

#### What is changing?

Just waiting on https://spruce.mongodb.com/task/libmongocrypt_release_publish_upload_all_9a88ac5698e8e3ffcd6580b98c247f0126f26c40_24_08_01_18_30_17/logs?execution=0.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Update bindings to use libmongocrypt 1.11.0

- Support `range` algorithm as stable.

See the [libmongocrypt release here](https://github.com/mongodb/libmongocrypt/releases/tag/1.11.0)

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
