### PR TITLE
feat(NODE-6695): enable KMS retry protocol

### DIFF
--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -575,6 +575,8 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
 
     mongocrypt_setopt_use_need_kms_credentials_state(mongo_crypt());
 
+    mongocrypt_setopt_retry_kms(mongo_crypt(), true);
+
     // Initialize after all options are set.
     if (!mongocrypt_init(mongo_crypt())) {
         throw TypeError::New(Env(), errorStringFromStatus(mongo_crypt()));
@@ -947,6 +949,8 @@ Function MongoCryptKMSRequest::Init(Napi::Env env) {
         {InstanceMethod("addResponse", &MongoCryptKMSRequest::AddResponse),
          InstanceAccessor("status", &MongoCryptKMSRequest::Status, nullptr),
          InstanceAccessor("bytesNeeded", &MongoCryptKMSRequest::BytesNeeded, nullptr),
+         InstanceAccessor("uSleep", &MongoCryptKMSRequest::USleep, nullptr),
+         InstanceAccessor("fail", &MongoCryptKMSRequest::Fail, nullptr),
          InstanceAccessor("kmsProvider", &MongoCryptKMSRequest::KMSProvider, nullptr),
          InstanceAccessor("endpoint", &MongoCryptKMSRequest::Endpoint, nullptr),
          InstanceAccessor("message", &MongoCryptKMSRequest::Message, nullptr)});
@@ -975,6 +979,14 @@ Value MongoCryptKMSRequest::Status(const CallbackInfo& info) {
 
 Value MongoCryptKMSRequest::BytesNeeded(const CallbackInfo& info) {
     return Number::New(Env(), mongocrypt_kms_ctx_bytes_needed(_kms_context));
+}
+
+Value MongoCryptKMSRequest::USleep(const CallbackInfo& info) {
+    return Number::New(Env(), mongocrypt_kms_ctx_usleep(_kms_context));
+}
+
+Value MongoCryptKMSRequest::Fail(const CallbackInfo& info) {
+    return Boolean::New(Env(), mongocrypt_kms_ctx_fail(_kms_context));
 }
 
 Value MongoCryptKMSRequest::KMSProvider(const CallbackInfo& info) {

--- a/addon/mongocrypt.h
+++ b/addon/mongocrypt.h
@@ -151,6 +151,8 @@ class MongoCryptKMSRequest : public Napi::ObjectWrap<MongoCryptKMSRequest> {
     Napi::Value Status(const Napi::CallbackInfo& info);
     Napi::Value Message(const Napi::CallbackInfo& info);
     Napi::Value BytesNeeded(const Napi::CallbackInfo& info);
+    Napi::Value Fail(const Napi::CallbackInfo& info);
+    Napi::Value USleep(const Napi::CallbackInfo& info);
     Napi::Value KMSProvider(const Napi::CallbackInfo& info);
     Napi::Value Endpoint(const Napi::CallbackInfo& info);
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.11.0",
+  "mongodb:libmongocrypt": "1.12.0",
   "dependencies": {
     "node-addon-api": "^4.3.0",
     "prebuild-install": "^7.1.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,10 @@ type MongoCryptBindings = {
 
 export interface MongoCryptKMSRequest {
   addResponse(response: Uint8Array): void;
+  fail(): boolean;
   readonly status: MongoCryptStatus;
   readonly bytesNeeded: number;
+  readonly uSleep: number;
   readonly kmsProvider: string;
   readonly endpoint: string;
   readonly message: Buffer;


### PR DESCRIPTION
### Description

Exposes methods required to retry KMS requests and enables them in libmongocrypt.

#### What is changing?

- Set the flag to retry KMS requests.
- Adds uSleep property and fail method.
- Bumps libmongocrypt to 1.12.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6695

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### KMS requests are now retryable

Retrying KMS requests is now enabled and the new method `uSleep` and `fail` property are now exposed to handle the feature in the driver.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
