### PR TITLE
fix: set fail as instance method

### DIFF
--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -947,10 +947,10 @@ Function MongoCryptKMSRequest::Init(Napi::Env env) {
         env,
         "MongoCryptKMSRequest",
         {InstanceMethod("addResponse", &MongoCryptKMSRequest::AddResponse),
+         InstanceMethod("fail", &MongoCryptKMSRequest::Fail),
          InstanceAccessor("status", &MongoCryptKMSRequest::Status, nullptr),
          InstanceAccessor("bytesNeeded", &MongoCryptKMSRequest::BytesNeeded, nullptr),
          InstanceAccessor("uSleep", &MongoCryptKMSRequest::USleep, nullptr),
-         InstanceAccessor("fail", &MongoCryptKMSRequest::Fail, nullptr),
          InstanceAccessor("kmsProvider", &MongoCryptKMSRequest::KMSProvider, nullptr),
          InstanceAccessor("endpoint", &MongoCryptKMSRequest::Endpoint, nullptr),
          InstanceAccessor("message", &MongoCryptKMSRequest::Message, nullptr)});


### PR DESCRIPTION
### Description

Fail is a method not a property. This is a quick fix.

#### What is changing?

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
