### PR TITLE
chore(NODE-6726): make install libmongocrypt script faster

### DIFF
--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -11,7 +11,7 @@ ENV PATH=$PATH:/nodejs/bin
 WORKDIR /mongodb-client-encryption
 COPY . .
 
-RUN apt-get -qq update && apt-get -qq install -y python3 build-essential && ldd --version
+RUN apt-get -qq update && apt-get -qq install -y python3 build-essential git && ldd --version
 
 RUN npm run install:libmongocrypt
 

--- a/.github/scripts/get-commit-from-ref.sh
+++ b/.github/scripts/get-commit-from-ref.sh
@@ -3,7 +3,7 @@
 git clone https://github.com/mongodb/libmongocrypt.git _libmongocrypt
 cd _libmongocrypt
 
-git switch --detach $REF
+git checkout --detach $REF
 
 COMMIT_HASH=$(git rev-parse HEAD)
 

--- a/.github/scripts/get-commit-from-ref.sh
+++ b/.github/scripts/get-commit-from-ref.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -o errexit
 
 git clone https://github.com/mongodb/libmongocrypt.git _libmongocrypt
 cd _libmongocrypt

--- a/.github/scripts/get-commit-from-ref.sh
+++ b/.github/scripts/get-commit-from-ref.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+git clone https://github.com/mongodb/libmongocrypt.git _libmongocrypt
+cd _libmongocrypt
+
+git switch --detach $REF
+
+COMMIT_HASH=$(git rev-parse HEAD)
+
+echo "COMMIT_HASH=$COMMIT_HASH"
+
+cd -
+rm -rf _libmongocrypt

--- a/.github/scripts/utils.mjs
+++ b/.github/scripts/utils.mjs
@@ -1,0 +1,82 @@
+// @ts-check
+
+import { execSync } from "child_process";
+import path from "path";
+import url from 'node:url';
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+/** Resolves to the root of this repository */
+export function resolveRoot(...paths) {
+    return path.resolve(__dirname, '..', '..', ...paths);
+}
+
+export function getCommitFromRef(ref) {
+    console.error(`resolving ref: ${ref}`);
+    const script = resolveRoot('.github', 'scripts', 'get-commit-from-ref.sh');
+    const output = execSync(`bash ${script}`, { env: { REF: ref }, encoding: 'utf-8' })
+
+    const regex = /COMMIT_HASH=(?<hash>[a-zA-Z0-9]+)/
+    const result = regex.exec(output);
+
+    if (!result?.groups) throw new Error('unable to parse ref.')
+
+    const { hash } = result.groups;
+
+    console.error(`resolved to: ${hash}`);
+    return hash;
+}
+
+export function buildLibmongocryptDownloadUrl(ref, platform) {
+    const hash = getCommitFromRef(ref);
+
+    // sort of a hack - if we have an official release version, it'll be in the form `major.minor`.  otherwise,
+    // we'd expect a commit hash or `master`.
+    if (ref.includes('.')) {
+        const [major, minor, patch] = ref.split('.');
+        if (patch !== '0') {
+            throw new Error('cannot release from non-zero patch.');
+        }
+
+        const branch = `r${major}.${minor}`
+        return `https://mciuploads.s3.amazonaws.com/libmongocrypt-release/${platform}/${branch}/${hash}/libmongocrypt.tar.gz`;
+    }
+
+    return `https://mciuploads.s3.amazonaws.com/libmongocrypt/${platform}/master/${hash}/libmongocrypt.tar.gz`;
+}
+
+export function getLibmongocryptPrebuildName() {
+    const platformMatrix = {
+        ['darwin-arm64']: 'macos',
+        ['darwin-x64']: 'macos',
+        ['linux-ppc64']: 'rhel-71-ppc64el',
+        ['linux-s390x']: 'rhel72-zseries-test',
+        ['linux-arm64']: 'ubuntu1804-arm64',
+        ['linux-x64']: 'rhel-70-64-bit',
+        ['win32-x64']: 'windows-test'
+    };
+
+    const detectedPlatform = `${process.platform}-${process.arch}`;
+    const prebuild = platformMatrix[detectedPlatform];
+
+    if (prebuild == null) throw new Error(`Unsupported: ${detectedPlatform}`);
+
+    return prebuild;
+}
+
+/** `xtrace` style command runner, uses spawn so that stdio is inherited */
+export async function run(command, args = [], options = {}) {
+    const commandDetails = `+ ${command} ${args.join(' ')}${options.cwd ? ` (in: ${options.cwd})` : ''}`;
+    console.error(commandDetails);
+    const proc = spawn(command, args, {
+        shell: process.platform === 'win32',
+        stdio: 'inherit',
+        cwd: resolveRoot('.'),
+        ...options
+    });
+    await once(proc, 'exit');
+
+    if (proc.exitCode != 0) throw new Error(`CRASH(${proc.exitCode}): ${commandDetails}`);
+}

--- a/.github/scripts/utils.mjs
+++ b/.github/scripts/utils.mjs
@@ -35,15 +35,22 @@ export function buildLibmongocryptDownloadUrl(ref, platform) {
     // sort of a hack - if we have an official release version, it'll be in the form `major.minor`.  otherwise,
     // we'd expect a commit hash or `master`.
     if (ref.includes('.')) {
-        const [major, minor, patch] = ref.split('.');
-        if (patch !== '0') {
-            throw new Error('cannot release from non-zero patch.');
-        }
+        const [major, minor, _patch] = ref.split('.');
 
+        // Just a note: it may appear that this logic _doesn't_ support patch releases but it actually does.
+        // libmongocrypt's creates release branches for minor releases in the form `r<major>.<minor>`.  
+        // Any patches made to this branch are committed as tags in the form <major>.<minor>.<patch>.
+        // So, the branch that is used for the AWS s3 upload is `r<major>.<minor>` and the commit hash
+        // is the commit hash we parse from the `getCommitFromRef()` (which handles switching to git tags and
+        // getting the commit hash at that tag just fine).
         const branch = `r${major}.${minor}`
+
         return `https://mciuploads.s3.amazonaws.com/libmongocrypt-release/${platform}/${branch}/${hash}/libmongocrypt.tar.gz`;
     }
 
+    // just a note here - `master` refers to the branch, the hash is the commit on that branch.
+    // if we ever need to download binaries from a non-master branch (or non-release branch), 
+    // this will need to be modified somehow.
     return `https://mciuploads.s3.amazonaws.com/libmongocrypt/${platform}/master/${hash}/libmongocrypt.tar.gz`;
 }
 


### PR DESCRIPTION
### Description

#### What is changing?

Improvements to the `libmongocrypt.mjs` script.  Primarily, this PR makes libmongocrypt's download much faster by only downloading binaries for the current platform, instead of a single tarball containing all binaries for all platforms.

I also reorganized the scripts a bit.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
