### PR TITLE
feat(NODE-6773): add multiple collinfo option

### DIFF
--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -577,6 +577,8 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
 
     mongocrypt_setopt_retry_kms(mongo_crypt(), true);
 
+    mongocrypt_setopt_enable_multiple_collinfo(mongo_crypt());
+
     // Initialize after all options are set.
     if (!mongocrypt_init(mongo_crypt())) {
         throw TypeError::New(Env(), errorStringFromStatus(mongo_crypt()));

--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -578,6 +578,7 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
     mongocrypt_setopt_retry_kms(mongo_crypt(), true);
 
     if (options.Get("enableMultipleCollinfo").ToBoolean()) {
+        /** TODO(NODE-6793): remove this option and have it always set in the next major */
         mongocrypt_setopt_enable_multiple_collinfo(mongo_crypt());
     }
 

--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -577,7 +577,9 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
 
     mongocrypt_setopt_retry_kms(mongo_crypt(), true);
 
-    mongocrypt_setopt_enable_multiple_collinfo(mongo_crypt());
+    if (options.Get("enableMultipleCollinfo").ToBoolean()) {
+        mongocrypt_setopt_enable_multiple_collinfo(mongo_crypt());
+    }
 
     // Initialize after all options are set.
     if (!mongocrypt_init(mongo_crypt())) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "67f10bfb8de69549987cc62a1d4548d7b511a7ef",
+  "mongodb:libmongocrypt": "1.13.0",
   "dependencies": {
     "node-addon-api": "^4.3.0",
     "prebuild-install": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.12.0",
+  "mongodb:libmongocrypt": "67f10bfb8de69549987cc62a1d4548d7b511a7ef",
   "dependencies": {
     "node-addon-api": "^4.3.0",
     "prebuild-install": "^7.1.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,8 +54,8 @@ export interface MongoCryptContext {
   finishKMSRequests(): void;
   finalize(): Buffer;
 
-  readonly status: MongoCryptStatus;
-  readonly state: number;
+  get status(): MongoCryptStatus;
+  get state(): number;
 }
 
 type MongoCryptConstructorOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ type MongoCryptConstructorOptions = {
   cryptSharedLibSearchPaths?: string[];
   cryptSharedLibPath?: string;
   bypassQueryAnalysis?: boolean;
+  enableMultipleCollinfo?: boolean;
 };
 
 export interface MongoCryptConstructor {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ type MongoCryptConstructorOptions = {
   cryptSharedLibSearchPaths?: string[];
   cryptSharedLibPath?: string;
   bypassQueryAnalysis?: boolean;
+  /** TODO(NODE-6793): remove this option and have it always set in the next major */
   enableMultipleCollinfo?: boolean;
 };
 


### PR DESCRIPTION
### Description


#### What is changing?

- Upgrade to libmongocrypt 1.13.
- Add option to enable mongocrypt_setopt_enable_multiple_collinfo.

##### Is there new documentation needed for these changes?

#### What is the motivation for this change?


### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Enables multiple collection info support for $lookup aggregations

Calls `mongocrypt_setopt_enable_multiple_collinfo` to enable the setting

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Ran `npm run check:lint` script
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
