### PR TITLE
chore(NODE-6936): update typescript to 5.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "standard-version": "^9.5.0",
         "tar": "^7.4.3",
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.3",
+        "typescript": "^5.8.3",
         "typescript-cached-transpile": "^0.0.6"
       },
       "engines": {
@@ -8080,9 +8080,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "standard-version": "^9.5.0",
     "tar": "^7.4.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3",
+    "typescript": "^5.8.3",
     "typescript-cached-transpile": "^0.0.6"
   },
   "overrides": {

--- a/test/bundling/webpack/package.json
+++ b/test/bundling/webpack/package.json
@@ -16,7 +16,7 @@
     "@webpack-cli/generators": "^3.0.1",
     "node-loader": "^2.1.0",
     "ts-loader": "^9.4.2",
-    "typescript": "^4.9.5",
+    "typescript": "^5.8.3",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonJS",
     "moduleResolution": "node",
     "skipLibCheck": true,
+    "erasableSyntaxOnly": true,
     "lib": [
       "es2020", "es2021.WeakRef"
     ],


### PR DESCRIPTION
### Description

Updates typescript to 5.8.3

#### What is changing?
- Update typescript.
- Enable `erasableSyntaxOnly` option.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6936

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
