### PR TITLE
feat(NODE-6947): add keyExpirationMS to bindings

### DIFF
--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -572,8 +572,8 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
     }
 
     if (options.Has("keyExpirationMS")) {
-        mongocrypt_setopt_key_expiration(
-            mongo_crypt(), options.Get("keyExpirationMS").ToNumber().Int64Value());
+        mongocrypt_setopt_key_expiration(mongo_crypt(),
+                                         options.Get("keyExpirationMS").ToNumber().Int64Value());
     }
 
     mongocrypt_setopt_use_range_v2(mongo_crypt());

--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -572,8 +572,11 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
     }
 
     if (options.Has("keyExpirationMS")) {
-        mongocrypt_setopt_key_expiration(mongo_crypt(),
-                                         options.Get("keyExpirationMS").ToNumber().Int64Value());
+        int64_t keyExpirationMS = options.Get("keyExpirationMS").ToNumber().Int64Value();
+        if (keyExpirationMS < 0) {
+            throw TypeError::New(Env(), "Option `keyExpirationMS` must be a non-negative number");
+        }
+        mongocrypt_setopt_key_expiration(mongo_crypt(), keyExpirationMS);
     }
 
     mongocrypt_setopt_use_range_v2(mongo_crypt());

--- a/addon/mongocrypt.cc
+++ b/addon/mongocrypt.cc
@@ -571,6 +571,11 @@ MongoCrypt::MongoCrypt(const CallbackInfo& info) : ObjectWrap(info) {
         mongocrypt_setopt_bypass_query_analysis(mongo_crypt());
     }
 
+    if (options.Has("keyExpirationMS")) {
+        mongocrypt_setopt_key_expiration(
+            mongo_crypt(), options.Get("keyExpirationMS").ToNumber().Int64Value());
+    }
+
     mongocrypt_setopt_use_range_v2(mongo_crypt());
 
     mongocrypt_setopt_use_need_kms_credentials_state(mongo_crypt());

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.13.0",
+  "mongodb:libmongocrypt": "1.14.0",
   "dependencies": {
     "node-addon-api": "^4.3.0",
     "prebuild-install": "^7.1.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ type MongoCryptConstructorOptions = {
   cryptSharedLibSearchPaths?: string[];
   cryptSharedLibPath?: string;
   bypassQueryAnalysis?: boolean;
+  /** Configure the time to expire the DEK from the cache. */
+  keyExpirationMS: number;
   /** TODO(NODE-6793): remove this option and have it always set in the next major */
   enableMultipleCollinfo?: boolean;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ type MongoCryptConstructorOptions = {
   cryptSharedLibPath?: string;
   bypassQueryAnalysis?: boolean;
   /** Configure the time to expire the DEK from the cache. */
-  keyExpirationMS: number;
+  keyExpirationMS?: number;
   /** TODO(NODE-6793): remove this option and have it always set in the next major */
   enableMultipleCollinfo?: boolean;
 };

--- a/test/unit/bindings.test.ts
+++ b/test/unit/bindings.test.ts
@@ -110,7 +110,7 @@ describe('MongoCryptConstructor', () => {
       it('throws an error', () => {
         expect(() => {
           new MongoCrypt({ kmsProviders: serialize({ aws: {} }), keyExpirationMS: -1000000 });
-        }).to.throw(TypeError);
+        }).to.throw(/must be a non-negative number/);
       });
     });
   });

--- a/test/unit/bindings.test.ts
+++ b/test/unit/bindings.test.ts
@@ -97,6 +97,24 @@ describe('MongoCryptConstructor', () => {
     });
   });
 
+  describe('options.keyExpirationMS', () => {
+    context('when the number is positive', () => {
+      it('does not error', () => {
+        expect(
+          new MongoCrypt({ kmsProviders: serialize({ aws: {} }), keyExpirationMS: 1000000 })
+        ).to.be.instanceOf(MongoCrypt);
+      });
+    });
+
+    context('when the number is negative', () => {
+      it('throws an error', () => {
+        expect(() => {
+          new MongoCrypt({ kmsProviders: serialize({ aws: {} }), keyExpirationMS: -1000000 });
+        }).to.throw(TypeError);
+      });
+    });
+  });
+
   describe('options.encryptedFieldsMap', () => {
     it('throws when provided and not a Uint8Array', () => {
       expect(


### PR DESCRIPTION
### Description

Adds the option `keyExpirationMS` to set the DEK cache expiration time.

#### What is changing?
- Adds the `keyExpirationMS` option to the TS types.
- Sets the option if provided when constructing a MongoCrypt.
- Updates libmongocrypt to 1.14

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6947

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### DEK cache expiration time now configurable.

A new option, `keyExpirationMS` can now be provided to set the new value. The default is 60000

```ts
import { MongoCrypt } from 'mongodb-client-encryption';
const crypt = new MongoCrypt({ keyExpirationMS: 100000 });
```

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run check:lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
