### PR TITLE
feat(NODE-7043): add support for custom error wrapping functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,15 @@
     "prettier/prettier": "error",
     "no-console": "error",
     "valid-typeof": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "eqeqeq": [
       "error",
       "always",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,0 +1,138 @@
+function load() {
+  try {
+    return require('../build/Release/mongocrypt.node');
+  } catch {
+    // Webpack will fail when just returning the require, so we need to wrap
+    // in a try/catch and rethrow.
+    /* eslint no-useless-catch: 0 */
+    try {
+      return require('../build/Debug/mongocrypt.node');
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+export const mc: MongoCryptBindings = load();
+
+export interface MongoCryptConstructor {
+  new (options: MongoCryptConstructorOptions): IMongoCrypt;
+  libmongocryptVersion: string;
+}
+
+interface MongoCryptContextCtor {
+  new (): IMongoCryptContext;
+}
+
+/**
+ * The value returned by the native bindings
+ * reference the `Init(Env env, Object exports)` function in the c++
+ */
+type MongoCryptBindings = {
+  MongoCrypt: MongoCryptConstructor;
+  MongoCryptContextCtor: MongoCryptContextCtor;
+  MongoCryptKMSRequestCtor: MongoCryptKMSRequest;
+};
+
+export interface MongoCryptStatus {
+  type: number;
+  code: number;
+  message?: string;
+}
+
+export interface MongoCryptKMSRequest {
+  addResponse(response: Uint8Array): void;
+  fail(): boolean;
+  readonly status: MongoCryptStatus;
+  readonly bytesNeeded: number;
+  readonly uSleep: number;
+  readonly kmsProvider: string;
+  readonly endpoint: string;
+  readonly message: Buffer;
+}
+
+export interface IMongoCryptContext {
+  nextMongoOperation(): Buffer;
+  addMongoOperationResponse(response: Uint8Array): void;
+  finishMongoOperation(): void;
+  nextKMSRequest(): MongoCryptKMSRequest | null;
+  provideKMSProviders(providers: Uint8Array): void;
+  finishKMSRequests(): void;
+  finalize(): Buffer;
+
+  get status(): MongoCryptStatus;
+  get state(): number;
+}
+
+export type MongoCryptConstructorOptions = {
+  kmsProviders?: Uint8Array;
+  schemaMap?: Uint8Array;
+  encryptedFieldsMap?: Uint8Array;
+  logger?: unknown;
+  cryptoCallbacks?: Record<string, unknown>;
+  cryptSharedLibSearchPaths?: string[];
+  cryptSharedLibPath?: string;
+  bypassQueryAnalysis?: boolean;
+  /** Configure the time to expire the DEK from the cache. */
+  keyExpirationMS?: number;
+
+  /**
+   * A function that wraps any errors that are thrown by the bindings in this package
+   * into a new error type.
+   *
+   * Example wrapper function, using the MongoDB driver:
+   * ```typescript
+   * (error: Error) => new MongoClientEncryptionError(error.message, { cause: error });
+   * ```
+   */
+  errorWrapper: (error: Error) => Error;
+};
+
+export interface IMongoCrypt {
+  makeEncryptionContext(ns: string, command: Uint8Array): IMongoCryptContext;
+  makeExplicitEncryptionContext(
+    value: Uint8Array,
+    options?: {
+      keyId?: Uint8Array;
+      keyAltName?: Uint8Array;
+      algorithm?: string;
+      rangeOptions?: Uint8Array;
+      textOptions?: Uint8Array;
+      contentionFactor?: bigint | number;
+      queryType?: string;
+
+      /**
+       * node-binding specific option
+       *
+       * When true, creates a `mongocrypt_ctx_explicit_encrypt_expression` context.
+       * When false, creates a `mongocrypt_ctx_explicit_encrypt`
+       */
+      expressionMode: boolean;
+    }
+  ): IMongoCryptContext;
+  makeDecryptionContext(buffer: Uint8Array): IMongoCryptContext;
+  makeExplicitDecryptionContext(buffer: Uint8Array): IMongoCryptContext;
+  makeDataKeyContext(
+    optionsBuffer: Uint8Array,
+    options: {
+      keyAltNames?: Uint8Array[];
+      keyMaterial?: Uint8Array;
+    }
+  ): IMongoCryptContext;
+  makeRewrapManyDataKeyContext(filter: Uint8Array, encryptionKey?: Uint8Array): IMongoCryptContext;
+  readonly status: MongoCryptStatus;
+  readonly cryptSharedLibVersionInfo: {
+    version: bigint;
+    versionStr: string;
+  } | null;
+  readonly cryptoHooksProvider: 'js' | 'native_openssl' | null;
+}
+
+export type ExplicitEncryptionContextOptions = NonNullable<
+  Parameters<IMongoCrypt['makeExplicitEncryptionContext']>[1]
+>;
+export type DataKeyContextOptions = NonNullable<Parameters<IMongoCrypt['makeDataKeyContext']>[1]>;
+export type MongoCryptOptions = MongoCryptConstructorOptions;
+export type MongoCryptErrorWrapper = MongoCryptOptions['errorWrapper'];
+
+// export const

--- a/test/bundling/webpack/src/index.ts
+++ b/test/bundling/webpack/src/index.ts
@@ -1,4 +1,8 @@
 import { MongoCrypt } from 'mongodb-client-encryption';
 
 // eslint-disable-next-line no-console
-console.log(new MongoCrypt({}));
+console.log(
+  new MongoCrypt({
+    errorWrapper: (e: Error) => e
+  })
+);

--- a/test/unit/error_wrapper.test.ts
+++ b/test/unit/error_wrapper.test.ts
@@ -1,0 +1,180 @@
+import { expect } from 'chai';
+import { MongoCrypt, MongoCryptContext } from '../../src';
+import {
+  IMongoCrypt,
+  IMongoCryptContext,
+  MongoCryptKMSRequest,
+  MongoCryptStatus
+} from '../../src/bindings';
+import { serialize } from 'bson';
+
+class CustomError extends Error {}
+
+describe('custom error wrapper functionality', function () {
+  describe('class MongoCryptContext', function () {
+    let context: MongoCryptContext;
+
+    beforeEach(function () {
+      class MockBindingsContext implements IMongoCryptContext {
+        nextMongoOperation(): Buffer {
+          throw new Error('ahh');
+        }
+        addMongoOperationResponse(_response: Uint8Array): void {
+          throw new Error('ahh');
+        }
+        finishMongoOperation(): void {
+          throw new Error('ahh');
+        }
+        nextKMSRequest(): MongoCryptKMSRequest | null {
+          throw new Error('ahh');
+        }
+        provideKMSProviders(_providers: Uint8Array): void {
+          throw new Error('ahh');
+        }
+        finishKMSRequests(): void {
+          throw new Error('ahh');
+        }
+        finalize(): Buffer {
+          throw new Error('ahh');
+        }
+        get status(): MongoCryptStatus {
+          throw new Error('ahh');
+        }
+        get state(): number {
+          throw new Error('ahh');
+        }
+      }
+
+      context = new MongoCryptContext(
+        new MockBindingsContext(),
+        error => new CustomError('custom error', { cause: error })
+      );
+    });
+
+    it('#nextMongoOperation() wraps errors from the bindings', function () {
+      expect(() => context.nextMongoOperation()).to.throw(CustomError);
+    });
+
+    it('#addMongoOperationResponse() wraps errors from the bindings', function () {
+      expect(() => context.addMongoOperationResponse(Buffer.from([1, 2, 3]))).to.throw(CustomError);
+    });
+
+    it('#finishMongoOperation() wraps errors from the bindings', function () {
+      expect(() => context.finishMongoOperation()).to.throw(CustomError);
+    });
+
+    it('#nextKMSRequest() wraps errors from the bindings', function () {
+      expect(() => context.nextKMSRequest()).to.throw(CustomError);
+    });
+
+    it('#provideKMSProviders() wraps errors from the bindings', function () {
+      expect(() => context.provideKMSProviders(Buffer.from([1, 2, 3]))).to.throw(CustomError);
+    });
+
+    it('#finishKMSRequests() wraps errors from the bindings', function () {
+      expect(() => context.finishKMSRequests()).to.throw(CustomError);
+    });
+
+    it('#finalize() wraps errors from the bindings', function () {
+      expect(() => context.finalize()).to.throw(CustomError);
+    });
+
+    it('.status wraps errors from the bindings', function () {
+      expect(() => context.status).to.throw(CustomError);
+    });
+
+    it('.state wraps errors from the bindings', function () {
+      expect(() => context.state).to.throw(CustomError);
+    });
+  });
+
+  describe('class MongoCrypt', function () {
+    let context: IMongoCrypt;
+
+    beforeEach(function () {
+      class MockMongoCrypt implements IMongoCrypt {
+        makeEncryptionContext(_ns: string, _command: Uint8Array): IMongoCryptContext {
+          throw new Error('Method not implemented.');
+        }
+        makeExplicitEncryptionContext(
+          _value: Uint8Array,
+          _options?: {
+            keyId?: Uint8Array;
+            keyAltName?: Uint8Array;
+            algorithm?: string;
+            rangeOptions?: Uint8Array;
+            textOptions?: Uint8Array;
+            contentionFactor?: bigint | number;
+            queryType?: string;
+            expressionMode: boolean;
+          }
+        ): IMongoCryptContext {
+          throw new Error('Method not implemented.');
+        }
+        makeDecryptionContext(_buffer: Uint8Array): IMongoCryptContext {
+          throw new Error('Method not implemented.');
+        }
+        makeExplicitDecryptionContext(_buffer: Uint8Array): IMongoCryptContext {
+          throw new Error('Method not implemented.');
+        }
+        makeDataKeyContext(
+          _optionsBuffer: Uint8Array,
+          _options: { keyAltNames?: Uint8Array[]; keyMaterial?: Uint8Array }
+        ): IMongoCryptContext {
+          throw new Error('Method not implemented.');
+        }
+        makeRewrapManyDataKeyContext(
+          _filter: Uint8Array,
+          _encryptionKey?: Uint8Array
+        ): IMongoCryptContext {
+          throw new Error('Method not implemented.');
+        }
+        get status(): MongoCryptStatus {
+          throw new Error('Method not implemented.');
+        }
+        cryptSharedLibVersionInfo: { version: bigint; versionStr: string };
+        cryptoHooksProvider: 'js' | 'native_openssl';
+      }
+
+      context = new MongoCrypt({
+        errorWrapper: error => new CustomError('custom error', { cause: error }),
+        kmsProviders: serialize({ aws: {} })
+      });
+
+      // @ts-expect-error accessing private property
+      context.mc = new MockMongoCrypt();
+    });
+
+    it('#makeEncryptionContext() wraps errors from the bindings', function () {
+      expect(() => context.makeEncryptionContext('db.collection', Buffer.from([1, 2, 3]))).to.throw(
+        CustomError
+      );
+    });
+
+    it('#makeExplicitEncryptionContext() wraps errors from the bindings', function () {
+      expect(() => context.makeExplicitEncryptionContext(Buffer.from([1, 2, 3]))).to.throw(
+        CustomError
+      );
+    });
+
+    it('#makeDecryptionContext() wraps errors from the bindings', function () {
+      expect(() => context.makeDecryptionContext(Buffer.from([1, 2, 3]))).to.throw(CustomError);
+    });
+
+    it('#makeExplicitDecryptionContext() wraps errors from the bindings', function () {
+      expect(() => context.makeExplicitDecryptionContext(Buffer.from([1, 2, 3]))).to.throw(
+        CustomError
+      );
+    });
+
+    it('#makeRewrapManyDataKeyContext() wraps errors from the bindings', function () {
+      expect(() => context.makeRewrapManyDataKeyContext(Buffer.from([1, 2, 3]))).to.throw(
+        CustomError
+      );
+    });
+
+    it('.status wraps errors from the bindings', function () {
+      expect(() => context.status).to.throw(CustomError);
+    });
+  });
+});

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -11,7 +11,7 @@ describe('index.ts', () => {
   });
 
   it('exposes MongoCryptContextCtor', () => {
-    expect(bindings).to.have.property('MongoCryptContextCtor').that.is.a('function');
+    expect(bindings).to.have.property('MongoCryptContext').that.is.a('function');
   });
 
   it('exposes MongoCryptKMSRequestCtor', () => {

--- a/test/unit/release.test.ts
+++ b/test/unit/release.test.ts
@@ -25,7 +25,13 @@ const REQUIRED_FILES = [
   'package/lib/crypto_callbacks.d.ts',
   'package/lib/crypto_callbacks.d.ts.map',
   'package/lib/crypto_callbacks.js',
-  'package/lib/crypto_callbacks.js.map'
+  'package/lib/crypto_callbacks.js.map',
+
+  'package/src/bindings.ts',
+  'package/lib/bindings.d.ts',
+  'package/lib/bindings.d.ts.map',
+  'package/lib/bindings.js',
+  'package/lib/bindings.js.map'
 ];
 
 describe(`Release ${packFile}`, function () {


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR adds support for a custom error-wrapping function in the bindings.  The function is used to wrap any error that is thrown from the C++ bindings.  This is accomplished by subclassing the classes exported from our C++ bindings with wrappers that try-catch any errors thrown from C++.

This PR has [a corresponding driver PR](https://github.com/mongodb/node-mongodb-native/pull/4694) that uses the error wrapper to wrap errors in a MongoCryptError.

Patch against driver: https://spruce.mongodb.com/version/68daedb19fc9d800072eb762/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC


#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

<!-- ### Release notes highlight ->
<!-- LEAVE EMPTY: we do not write release highlights for mongodb-client-encryption -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
