### PR TITLE
feat(NODE-6297)!: Remove support for explicitly providing CryptoCallbacks

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -64,6 +64,9 @@ export interface IMongoCryptContext {
   get state(): number;
 }
 
+/**
+ * All options that can be provided to a C++ MongoCrypt constructor.
+ */
 export type MongoCryptConstructorOptions = {
   kmsProviders?: Uint8Array;
   schemaMap?: Uint8Array;
@@ -132,7 +135,7 @@ export type ExplicitEncryptionContextOptions = NonNullable<
   Parameters<IMongoCrypt['makeExplicitEncryptionContext']>[1]
 >;
 export type DataKeyContextOptions = NonNullable<Parameters<IMongoCrypt['makeDataKeyContext']>[1]>;
-export type MongoCryptOptions = MongoCryptConstructorOptions;
+export type MongoCryptOptions = Omit<MongoCryptConstructorOptions, 'cryptoCallbacks'>;
 export type MongoCryptErrorWrapper = MongoCryptOptions['errorWrapper'];
 
 // export const

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,10 +96,7 @@ export class MongoCrypt implements IMongoCrypt {
   constructor(options: MongoCryptOptions) {
     // Pass in JS cryptoCallbacks implementation by default.
     // If the Node.js openssl version is supported this will be ignored.
-    this.mc = new mc.MongoCrypt(
-      // @ts-expect-error: intentionally passing in an argument that will throw to preserve existing behavior
-      options == null || typeof options !== 'object' ? undefined : { cryptoCallbacks, ...options }
-    );
+    this.mc = new mc.MongoCrypt({ cryptoCallbacks, ...options });
 
     this.errorWrapper = options.errorWrapper;
 


### PR DESCRIPTION
### Description

#### Summary of Changes

CryptoCallbacks are being removed from the driver in v7, so we no longer need to support them as an option in the MongoCrypt constructor.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

<!-- ### Release notes highlight ->
<!-- LEAVE EMPTY: we do not write release highlights for mongodb-client-encryption -->

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
