### PR TITLE
chore: fix release job, remove unused id-token permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ name: Build
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   host_builds:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ on:
 name: Build
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   host_builds:


### PR DESCRIPTION
### Description

#### Summary of Changes

Remove unused `id-token` permission.

#### What is the motivation for this change?

https://github.com/mongodb-js/mongodb-client-encryption/actions/runs/26313890802

> The workflow is not valid. .github/workflows/release.yml (Line: 23, Col: 3): Error calling workflow 'mongodb-js/mongodb-client-encryption/.github/workflows/build.yml@bb1633c78a8f9b4fff62d144d02fc1d52207d026'. The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
