### PR TITLE
feat(NODE-7569): update libmongocrypt URLs for 1.18.0+

### DIFF
--- a/.github/docker/Dockerfile.glibc
+++ b/.github/docker/Dockerfile.glibc
@@ -10,10 +10,10 @@ ENV PATH=$PATH:/nodejs/bin
 WORKDIR /mongodb-client-encryption
 COPY . .
 
-RUN yum -y install python39 git gcc-toolset-14
+RUN yum -y install python39 git gcc-toolset-14 cmake
 ENV PATH=/opt/rh/gcc-toolset-14/root/bin/:$PATH
 
-RUN npm run install:libmongocrypt
+RUN npm run install:libmongocrypt -- --build
 
 ARG RUN_TEST
 RUN if [ -n "$RUN_TEST" ]; then npm test ; else echo "skipping tests" ; fi

--- a/.github/docker/Dockerfile.musl
+++ b/.github/docker/Dockerfile.musl
@@ -7,7 +7,7 @@ WORKDIR /mongodb-client-encryption
 COPY . .
 
 RUN apk --no-cache add make g++ libc-dev curl bash python3 py3-pip cmake git
-RUN npm run install:libmongocrypt
+RUN npm run install:libmongocrypt -- --build
 RUN npm run prebuild
 
 ARG RUN_TEST

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -129,22 +129,31 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   });
 }
 
-async function downloadFile(url, destPath) {
-  const response = await new Promise((resolve, reject) => {
-    function request(requestUrl) {
-      https.get(requestUrl, res => {
-        if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 303) {
-          res.resume();
-          request(res.headers.location);
+async function getHttpResponse(url, redirectDepth = 0) {
+  if (redirectDepth > 5) throw new Error(`Too many redirects for ${url}`);
+
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
+        res.resume();
+        const location = res.headers.location;
+        if (!location) {
+          reject(new Error(`Redirect with no Location header from ${url}`));
           return;
         }
-        resolve(res);
-      }).on('error', reject);
-    }
-    request(url);
+        getHttpResponse(location, redirectDepth + 1).then(resolve, reject);
+        return;
+      }
+      resolve(res);
+    }).on('error', reject);
   });
+}
+
+async function downloadFile(url, destPath) {
+  const response = await getHttpResponse(url);
 
   if (response.statusCode !== 200) {
+    response.resume();
     throw new Error(`HTTP ${response.statusCode} downloading ${url}`);
   }
 
@@ -154,15 +163,25 @@ async function downloadFile(url, destPath) {
 async function verifySignature(tarballPath, ascURL) {
   const ascPath = tarballPath.replace('.tar.gz', '.asc');
   const pubKeyPath = resolveRoot('_libmongocrypt.pub');
+  const gnupgHome = resolveRoot('_gnupghome');
 
   try {
     await downloadFile(ascURL, ascPath);
     await downloadFile('https://pgp.mongodb.com/libmongocrypt.pub', pubKeyPath);
-    await run('gpg', ['--import', pubKeyPath]);
-    await run('gpg', ['--verify', ascPath, tarballPath]);
+    await fs.mkdir(gnupgHome, { recursive: true });
+    await fs.chmod(gnupgHome, 0o700);
+    const gpgEnv = { env: { ...process.env, GNUPGHOME: gnupgHome } };
+    await run('gpg', ['--batch', '--import', pubKeyPath], gpgEnv);
+    await run('gpg', ['--batch', '--verify', ascPath, tarballPath], gpgEnv);
+  } catch (error) {
+    if (error.message?.includes('CRASH') && error.message?.includes('gpg')) {
+      throw new Error(`GPG verification failed — ensure gnupg is installed. Original: ${error.message}`);
+    }
+    throw error;
   } finally {
     await fs.rm(ascPath, { force: true });
     await fs.rm(pubKeyPath, { force: true });
+    await fs.rm(gnupgHome, { recursive: true, force: true });
   }
 }
 

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -3,8 +3,7 @@
 import util from 'node:util';
 import process from 'node:process';
 import fs, { readFile } from 'node:fs/promises';
-import child_process from 'node:child_process';
-import events from 'node:events';
+import { createWriteStream } from 'node:fs';
 import path from 'node:path';
 import https from 'node:https';
 import stream from 'node:stream/promises';
@@ -130,47 +129,77 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   });
 }
 
+async function downloadFile(url, destPath) {
+  const response = await new Promise((resolve, reject) => {
+    function request(requestUrl) {
+      https.get(requestUrl, res => {
+        if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 303) {
+          res.resume();
+          request(res.headers.location);
+          return;
+        }
+        resolve(res);
+      }).on('error', reject);
+    }
+    request(url);
+  });
+
+  if (response.statusCode !== 200) {
+    throw new Error(`HTTP ${response.statusCode} downloading ${url}`);
+  }
+
+  await stream.pipeline(response, createWriteStream(destPath));
+}
+
+async function verifySignature(tarballPath, ascURL) {
+  const ascPath = tarballPath.replace('.tar.gz', '.asc');
+  const pubKeyPath = resolveRoot('_libmongocrypt.pub');
+
+  try {
+    await downloadFile(ascURL, ascPath);
+    await downloadFile('https://pgp.mongodb.com/libmongocrypt.pub', pubKeyPath);
+    await run('gpg', ['--import', pubKeyPath]);
+    await run('gpg', ['--verify', ascPath, tarballPath]);
+  } finally {
+    await fs.rm(ascPath, { force: true });
+    await fs.rm(pubKeyPath, { force: true });
+  }
+}
+
 export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
   const prebuild = getLibmongocryptPrebuildName();
-
   const downloadURL = buildLibmongocryptDownloadUrl(ref, prebuild);
 
   console.error('downloading libmongocrypt...', downloadURL);
-  const destination = resolveRoot(`_libmongocrypt-${ref}`);
 
-  await fs.rm(destination, { recursive: true, force: true });
-  await fs.mkdir(destination);
-
-  const downloadDestination = `nocrypto`;
-  const unzipArgs = ['-xzv', '-C', `_libmongocrypt-${ref}`, downloadDestination];
-  console.error(`+ tar ${unzipArgs.join(' ')}`);
-  const unzip = child_process.spawn('tar', unzipArgs, {
-    stdio: ['pipe', 'inherit', 'pipe'],
-    cwd: resolveRoot('.')
-  });
-  if (unzip.stdin == null) throw new Error('Tar process must have piped stdin');
-
-  const [response] = await events.once(https.get(downloadURL), 'response');
+  const tarballPath = resolveRoot(`_libmongocrypt-${ref}.tar.gz`);
 
   const start = performance.now();
-
-  try {
-    await stream.pipeline(response, unzip.stdin);
-  } catch {
-    await fs.access(path.join(`_libmongocrypt-${ref}`, downloadDestination));
-  }
-
+  await downloadFile(downloadURL, tarballPath);
   const end = performance.now();
 
   console.error(`downloaded libmongocrypt in ${(end - start) / 1000} secs...`);
 
+  if (ref.includes('.')) {
+    const ascURL = `https://github.com/mongodb/libmongocrypt/releases/download/${ref}/libmongocrypt-${prebuild}-${ref}.asc`;
+    await verifySignature(tarballPath, ascURL);
+  }
+
+  const destination = resolveRoot(`_libmongocrypt-${ref}`);
+  await fs.rm(destination, { recursive: true, force: true });
+  await fs.mkdir(destination);
+
+  await run('tar', ['-xzv', '-C', destination, '-f', tarballPath]);
+  await fs.rm(tarballPath, { force: true });
+
   await fs.rm(nodeDepsRoot, { recursive: true, force: true });
-  await fs.cp(resolveRoot(destination, 'nocrypto'), nodeDepsRoot, { recursive: true });
+  await fs.cp(destination, nodeDepsRoot, { recursive: true });
+
   const potentialLib64Path = path.join(nodeDepsRoot, 'lib64');
   try {
     await fs.rename(potentialLib64Path, path.join(nodeDepsRoot, 'lib'));
-  } catch (error) {
-    await fs.access(path.join(nodeDepsRoot, 'lib')); // Ensure there is a "lib" directory
+  } catch {
+    await fs.access(path.join(nodeDepsRoot, 'lib'));
   }
 }
 

--- a/.github/scripts/utils.mjs
+++ b/.github/scripts/utils.mjs
@@ -35,7 +35,7 @@ export function buildLibmongocryptDownloadUrl(ref, platform) {
         return `https://github.com/mongodb/libmongocrypt/releases/download/${ref}/libmongocrypt-${platform}-${ref}.tar.gz`;
     }
 
-    // For development refs (master only), fall back to S3
+    // For development refs (e.g. master), fall back to S3
     const hash = getCommitFromRef(ref);
     return `https://mciuploads.s3.amazonaws.com/libmongocrypt/${platform}/master/${hash}/libmongocrypt.tar.gz`;
 }

--- a/.github/scripts/utils.mjs
+++ b/.github/scripts/utils.mjs
@@ -35,7 +35,7 @@ export function buildLibmongocryptDownloadUrl(ref, platform) {
         return `https://github.com/mongodb/libmongocrypt/releases/download/${ref}/libmongocrypt-${platform}-${ref}.tar.gz`;
     }
 
-    // For development refs (master, branches), fall back to S3
+    // For development refs (master only), fall back to S3
     const hash = getCommitFromRef(ref);
     return `https://mciuploads.s3.amazonaws.com/libmongocrypt/${platform}/master/${hash}/libmongocrypt.tar.gz`;
 }

--- a/.github/scripts/utils.mjs
+++ b/.github/scripts/utils.mjs
@@ -30,43 +30,29 @@ export function getCommitFromRef(ref) {
 }
 
 export function buildLibmongocryptDownloadUrl(ref, platform) {
-    const hash = getCommitFromRef(ref);
-
-    // sort of a hack - if we have an official release version, it'll be in the form `major.minor`.  otherwise,
-    // we'd expect a commit hash or `master`.
+    // libmongocrypt 1.18.0+ is distributed via GitHub Releases (S3 release bucket restricted per MONGOCRYPT-841)
     if (ref.includes('.')) {
-        const [major, minor, _patch] = ref.split('.');
-
-        // Just a note: it may appear that this logic _doesn't_ support patch releases but it actually does.
-        // libmongocrypt's creates release branches for minor releases in the form `r<major>.<minor>`.
-        // Any patches made to this branch are committed as tags in the form <major>.<minor>.<patch>.
-        // So, the branch that is used for the AWS s3 upload is `r<major>.<minor>` and the commit hash
-        // is the commit hash we parse from the `getCommitFromRef()` (which handles switching to git tags and
-        // getting the commit hash at that tag just fine).
-        const branch = `r${major}.${minor}`
-
-        return `https://mciuploads.s3.amazonaws.com/libmongocrypt-release/${platform}/${branch}/${hash}/libmongocrypt.tar.gz`;
+        return `https://github.com/mongodb/libmongocrypt/releases/download/${ref}/libmongocrypt-${platform}-${ref}.tar.gz`;
     }
 
-    // just a note here - `master` refers to the branch, the hash is the commit on that branch.
-    // if we ever need to download binaries from a non-master branch (or non-release branch),
-    // this will need to be modified somehow.
+    // For development refs (master, branches), fall back to S3
+    const hash = getCommitFromRef(ref);
     return `https://mciuploads.s3.amazonaws.com/libmongocrypt/${platform}/master/${hash}/libmongocrypt.tar.gz`;
 }
 
 export function getLibmongocryptPrebuildName() {
     const prebuildIdentifierFactory = {
-        'darwin': () => 'macos',
-        'win32': () => 'windows-test',
+        'darwin': () => 'macos-universal',
+        'win32': () => 'windows-x86_64',
         'linux': () => {
             const key = `${getLibc()}-${process.arch}`;
             return {
-                ['musl-x64']: 'alpine-amd64-earthly',
-                ['musl-arm64']: 'alpine-arm64-earthly',
-                ['glibc-ppc64']: 'rhel-71-ppc64el',
-                ['glibc-s390x']: 'rhel72-zseries-test',
-                ['glibc-arm64']: 'ubuntu1804-arm64',
-                ['glibc-x64']: 'rhel-70-64-bit',
+                ['musl-x64']: 'linux-x86_64-musl_1_2-nocrypto',
+                ['musl-arm64']: 'linux-arm64-musl_1_2-nocrypto',
+                ['glibc-ppc64']: 'linux-ppc64le-glibc_2_17-nocrypto',
+                ['glibc-s390x']: 'linux-s390x-glibc_2_7-nocrypto',
+                ['glibc-arm64']: 'linux-arm64-glibc_2_17-nocrypto',
+                ['glibc-x64']: 'linux-x86_64-glibc_2_7-nocrypto',
             }[key]
         }
     }[process.platform] ?? (() => {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build ${{ matrix.os }} Prebuild
-        run: node .github/scripts/libmongocrypt.mjs ${{ runner.os == 'Windows' && '--build' || '' }}
+        run: node .github/scripts/libmongocrypt.mjs --build
         shell: bash
 
       - id: upload

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.15.1",
+  "mongodb:libmongocrypt": "1.19.1",
   "dependencies": {
     "node-addon-api": "^8.5.0",
     "prebuild-install": "^7.1.3"


### PR DESCRIPTION
### Description

#### Summary of Changes

Bumps `mongodb:libmongocrypt` from `1.15.1` to `1.19.1` and updates the download script to use GitHub Releases instead of S3. The S3 release bucket was restricted starting with libmongocrypt 1.18.0 ([MONGOCRYPT-841](https://jira.mongodb.org/browse/MONGOCRYPT-841)), so version refs now resolve to `https://github.com/mongodb/libmongocrypt/releases/download/…`. GPG signature verification is added for all downloaded release tarballs.

<!-- RELEASE_HIGHLIGHT_START -->
<!-- LEAVE EMPTY: we do not write release highlights for mongodb-client-encryption -->
<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:eslint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket