### PR TITLE
feat(NODE-7569): upgrade to libmongocrypt 1.19.2 from GitHub Releases

### DIFF
--- a/.github/docker/Dockerfile.musl
+++ b/.github/docker/Dockerfile.musl
@@ -6,7 +6,7 @@ FROM ${PLATFORM}/node:${NODE_VERSION}-alpine AS build
 WORKDIR /mongodb-client-encryption
 COPY . .
 
-RUN apk --no-cache add make g++ libc-dev curl bash python3 py3-pip cmake git
+RUN apk --no-cache add make g++ libc-dev curl bash python3 py3-pip cmake git gnupg
 RUN npm run install:libmongocrypt
 RUN npm run prebuild
 

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -3,10 +3,10 @@
 import util from 'node:util';
 import process from 'node:process';
 import fs, { readFile } from 'node:fs/promises';
-import { createWriteStream } from 'node:fs';
 import path from 'node:path';
-import https from 'node:https';
-import stream from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createWriteStream } from 'node:fs';
 import {
   buildLibmongocryptDownloadUrl,
   getLibmongocryptPrebuildName,
@@ -129,35 +129,10 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   });
 }
 
-async function getHttpResponse(url, redirectDepth = 0) {
-  if (redirectDepth > 5) throw new Error(`Too many redirects for ${url}`);
-
-  return new Promise((resolve, reject) => {
-    https.get(url, res => {
-      if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
-        res.resume();
-        const location = res.headers.location;
-        if (!location) {
-          reject(new Error(`Redirect with no Location header from ${url}`));
-          return;
-        }
-        getHttpResponse(location, redirectDepth + 1).then(resolve, reject);
-        return;
-      }
-      resolve(res);
-    }).on('error', reject);
-  });
-}
-
 async function downloadFile(url, destPath) {
-  const response = await getHttpResponse(url);
-
-  if (response.statusCode !== 200) {
-    response.resume();
-    throw new Error(`HTTP ${response.statusCode} downloading ${url}`);
-  }
-
-  await stream.pipeline(response, createWriteStream(destPath));
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`HTTP ${response.status} downloading ${url}`);
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(destPath));
 }
 
 export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -6,7 +6,8 @@ import fs, { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { createWriteStream } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import {
   buildLibmongocryptDownloadUrl,
   getLibmongocryptPrebuildName,
@@ -129,35 +130,29 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   });
 }
 
-async function downloadFile(url, destPath) {
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`HTTP ${response.status} downloading ${url}`);
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(destPath));
-}
-
 export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
   const prebuild = getLibmongocryptPrebuildName();
   const downloadURL = buildLibmongocryptDownloadUrl(ref, prebuild);
 
   console.error('downloading libmongocrypt...', downloadURL);
 
-  const tarballPath = resolveRoot(`_libmongocrypt-${ref}.tar.gz`);
-
-  const start = performance.now();
-  await downloadFile(downloadURL, tarballPath);
-  const end = performance.now();
-
-  console.error(`downloaded libmongocrypt in ${(end - start) / 1000} secs...`);
-
   const destination = resolveRoot(`_libmongocrypt-${ref}`);
   await fs.rm(destination, { recursive: true, force: true });
   await fs.mkdir(destination);
 
-  // Use a relative path: Windows bsd-tar misinterprets absolute paths with drive
-  // letters (e.g. "D:\...") as URL hostnames in both -C and -f arguments.
-  const tarballRelPath = path.relative(destination, tarballPath).replace(/\\/g, '/');
-  await run('tar', ['-xzv', '-f', tarballRelPath], { cwd: destination });
-  await fs.rm(tarballPath, { force: true });
+  const response = await fetch(downloadURL);
+  if (!response.ok) throw new Error(`HTTP ${response.status} downloading ${downloadURL}`);
+
+  const start = performance.now();
+
+  const unzip = spawn('tar', ['-xzv', '-C', destination], { stdio: ['pipe', 'inherit', 'inherit'] });
+  await pipeline(Readable.fromWeb(response.body), unzip.stdin);
+  await once(unzip, 'exit');
+
+  if (unzip.exitCode !== 0) throw new Error(`tar exited with code ${unzip.exitCode}`);
+
+  const end = performance.now();
+  console.error(`downloaded libmongocrypt in ${(end - start) / 1000} secs...`);
 
   await fs.rm(nodeDepsRoot, { recursive: true, force: true });
   await fs.cp(destination, nodeDepsRoot, { recursive: true });

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -3,6 +3,7 @@
 import util from 'node:util';
 import process from 'node:process';
 import fs, { readFile } from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -130,6 +131,33 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   });
 }
 
+async function verifySignature(tarballPath, ref, prebuild) {
+  const ascURL = `https://github.com/mongodb/libmongocrypt/releases/download/${ref}/libmongocrypt-${prebuild}-${ref}.asc`;
+  const pubKeyURL = 'https://pgp.mongodb.com/libmongocrypt.pub';
+  const ascPath = `${tarballPath}.asc`;
+  const pubKeyPath = path.join(path.dirname(tarballPath), 'libmongocrypt.pub');
+
+  console.error('verifying libmongocrypt signature...');
+
+  try {
+    const [ascResponse, pubKeyResponse] = await Promise.all([fetch(ascURL), fetch(pubKeyURL)]);
+    if (!ascResponse.ok) throw new Error(`HTTP ${ascResponse.status} downloading ${ascURL}`);
+    if (!pubKeyResponse.ok) throw new Error(`HTTP ${pubKeyResponse.status} downloading ${pubKeyURL}`);
+
+    await Promise.all([
+      fs.writeFile(ascPath, Buffer.from(await ascResponse.arrayBuffer())),
+      fs.writeFile(pubKeyPath, Buffer.from(await pubKeyResponse.arrayBuffer()))
+    ]);
+
+    await run('gpg', ['--import', pubKeyPath]);
+    await run('gpg', ['--verify', ascPath, tarballPath]);
+  } finally {
+    await Promise.all([fs.rm(ascPath, { force: true }), fs.rm(pubKeyPath, { force: true })]);
+  }
+
+  console.error('libmongocrypt signature verified');
+}
+
 export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
   const prebuild = getLibmongocryptPrebuildName();
   const downloadURL = buildLibmongocryptDownloadUrl(ref, prebuild);
@@ -140,16 +168,26 @@ export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
   await fs.rm(destination, { recursive: true, force: true });
   await fs.mkdir(destination);
 
+  const tarballPath = resolveRoot(`_libmongocrypt-${ref}.tar.gz`);
+
   const response = await fetch(downloadURL);
   if (!response.ok) throw new Error(`HTTP ${response.status} downloading ${downloadURL}`);
 
   const start = performance.now();
 
-  const unzip = spawn('tar', ['-xzv', '-C', destination], { stdio: ['pipe', 'inherit', 'inherit'] });
-  await pipeline(Readable.fromWeb(response.body), unzip.stdin);
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(tarballPath));
+
+  // Verify GPG signature for GitHub releases (release refs contain '.')
+  if (ref.includes('.')) {
+    await verifySignature(tarballPath, ref, prebuild);
+  }
+
+  const unzip = spawn('tar', ['-xzv', '-C', destination, '-f', tarballPath], { stdio: ['ignore', 'inherit', 'inherit'] });
   await once(unzip, 'exit');
 
   if (unzip.exitCode !== 0) throw new Error(`tar exited with code ${unzip.exitCode}`);
+
+  await fs.rm(tarballPath, { force: true });
 
   const end = performance.now();
   console.error(`downloaded libmongocrypt in ${(end - start) / 1000} secs...`);

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -3,8 +3,7 @@
 import util from 'node:util';
 import process from 'node:process';
 import fs, { readFile } from 'node:fs/promises';
-import child_process from 'node:child_process';
-import events from 'node:events';
+import { createWriteStream } from 'node:fs';
 import path from 'node:path';
 import https from 'node:https';
 import stream from 'node:stream/promises';
@@ -130,47 +129,69 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   });
 }
 
+async function getHttpResponse(url, redirectDepth = 0) {
+  if (redirectDepth > 5) throw new Error(`Too many redirects for ${url}`);
+
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
+        res.resume();
+        const location = res.headers.location;
+        if (!location) {
+          reject(new Error(`Redirect with no Location header from ${url}`));
+          return;
+        }
+        getHttpResponse(location, redirectDepth + 1).then(resolve, reject);
+        return;
+      }
+      resolve(res);
+    }).on('error', reject);
+  });
+}
+
+async function downloadFile(url, destPath) {
+  const response = await getHttpResponse(url);
+
+  if (response.statusCode !== 200) {
+    response.resume();
+    throw new Error(`HTTP ${response.statusCode} downloading ${url}`);
+  }
+
+  await stream.pipeline(response, createWriteStream(destPath));
+}
+
 export async function downloadLibMongoCrypt(nodeDepsRoot, { ref }) {
   const prebuild = getLibmongocryptPrebuildName();
-
   const downloadURL = buildLibmongocryptDownloadUrl(ref, prebuild);
 
   console.error('downloading libmongocrypt...', downloadURL);
-  const destination = resolveRoot(`_libmongocrypt-${ref}`);
 
-  await fs.rm(destination, { recursive: true, force: true });
-  await fs.mkdir(destination);
-
-  const downloadDestination = `nocrypto`;
-  const unzipArgs = ['-xzv', '-C', `_libmongocrypt-${ref}`, downloadDestination];
-  console.error(`+ tar ${unzipArgs.join(' ')}`);
-  const unzip = child_process.spawn('tar', unzipArgs, {
-    stdio: ['pipe', 'inherit', 'pipe'],
-    cwd: resolveRoot('.')
-  });
-  if (unzip.stdin == null) throw new Error('Tar process must have piped stdin');
-
-  const [response] = await events.once(https.get(downloadURL), 'response');
+  const tarballPath = resolveRoot(`_libmongocrypt-${ref}.tar.gz`);
 
   const start = performance.now();
-
-  try {
-    await stream.pipeline(response, unzip.stdin);
-  } catch {
-    await fs.access(path.join(`_libmongocrypt-${ref}`, downloadDestination));
-  }
-
+  await downloadFile(downloadURL, tarballPath);
   const end = performance.now();
 
   console.error(`downloaded libmongocrypt in ${(end - start) / 1000} secs...`);
 
+  const destination = resolveRoot(`_libmongocrypt-${ref}`);
+  await fs.rm(destination, { recursive: true, force: true });
+  await fs.mkdir(destination);
+
+  // Use a relative path: Windows bsd-tar misinterprets absolute paths with drive
+  // letters (e.g. "D:\...") as URL hostnames in both -C and -f arguments.
+  const tarballRelPath = path.relative(destination, tarballPath).replace(/\\/g, '/');
+  await run('tar', ['-xzv', '-f', tarballRelPath], { cwd: destination });
+  await fs.rm(tarballPath, { force: true });
+
   await fs.rm(nodeDepsRoot, { recursive: true, force: true });
-  await fs.cp(resolveRoot(destination, 'nocrypto'), nodeDepsRoot, { recursive: true });
+  await fs.cp(destination, nodeDepsRoot, { recursive: true });
+
   const potentialLib64Path = path.join(nodeDepsRoot, 'lib64');
   try {
     await fs.rename(potentialLib64Path, path.join(nodeDepsRoot, 'lib'));
-  } catch (error) {
-    await fs.access(path.join(nodeDepsRoot, 'lib')); // Ensure there is a "lib" directory
+  } catch {
+    await fs.access(path.join(nodeDepsRoot, 'lib'));
   }
 }
 

--- a/.github/scripts/utils.mjs
+++ b/.github/scripts/utils.mjs
@@ -30,43 +30,29 @@ export function getCommitFromRef(ref) {
 }
 
 export function buildLibmongocryptDownloadUrl(ref, platform) {
-    const hash = getCommitFromRef(ref);
-
-    // sort of a hack - if we have an official release version, it'll be in the form `major.minor`.  otherwise,
-    // we'd expect a commit hash or `master`.
+    // libmongocrypt 1.18.0+ is distributed via GitHub Releases (S3 release bucket restricted per MONGOCRYPT-841)
     if (ref.includes('.')) {
-        const [major, minor, _patch] = ref.split('.');
-
-        // Just a note: it may appear that this logic _doesn't_ support patch releases but it actually does.
-        // libmongocrypt's creates release branches for minor releases in the form `r<major>.<minor>`.
-        // Any patches made to this branch are committed as tags in the form <major>.<minor>.<patch>.
-        // So, the branch that is used for the AWS s3 upload is `r<major>.<minor>` and the commit hash
-        // is the commit hash we parse from the `getCommitFromRef()` (which handles switching to git tags and
-        // getting the commit hash at that tag just fine).
-        const branch = `r${major}.${minor}`
-
-        return `https://mciuploads.s3.amazonaws.com/libmongocrypt-release/${platform}/${branch}/${hash}/libmongocrypt.tar.gz`;
+        return `https://github.com/mongodb/libmongocrypt/releases/download/${ref}/libmongocrypt-${platform}-${ref}.tar.gz`;
     }
 
-    // just a note here - `master` refers to the branch, the hash is the commit on that branch.
-    // if we ever need to download binaries from a non-master branch (or non-release branch),
-    // this will need to be modified somehow.
+    // For development refs (master only), fall back to S3
+    const hash = getCommitFromRef(ref);
     return `https://mciuploads.s3.amazonaws.com/libmongocrypt/${platform}/master/${hash}/libmongocrypt.tar.gz`;
 }
 
 export function getLibmongocryptPrebuildName() {
     const prebuildIdentifierFactory = {
-        'darwin': () => 'macos',
-        'win32': () => 'windows-test',
+        'darwin': () => 'macos-universal',
+        'win32': () => 'windows-x86_64',
         'linux': () => {
             const key = `${getLibc()}-${process.arch}`;
             return {
-                ['musl-x64']: 'alpine-amd64-earthly',
-                ['musl-arm64']: 'alpine-arm64-earthly',
-                ['glibc-ppc64']: 'rhel-71-ppc64el',
-                ['glibc-s390x']: 'rhel72-zseries-test',
-                ['glibc-arm64']: 'ubuntu1804-arm64',
-                ['glibc-x64']: 'rhel-70-64-bit',
+                ['musl-x64']: 'linux-x86_64-musl_1_2-nocrypto',
+                ['musl-arm64']: 'linux-arm64-musl_1_2-nocrypto',
+                ['glibc-ppc64']: 'linux-ppc64le-glibc_2_17-nocrypto',
+                ['glibc-s390x']: 'linux-s390x-glibc_2_7-nocrypto',
+                ['glibc-arm64']: 'linux-arm64-glibc_2_17-nocrypto',
+                ['glibc-x64']: 'linux-x86_64-glibc_2_7-nocrypto',
             }[key]
         }
     }[process.platform] ?? (() => {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build ${{ matrix.os }} Prebuild
-        run: node .github/scripts/libmongocrypt.mjs ${{ runner.os == 'Windows' && '--build' || '' }}
+        run: node .github/scripts/libmongocrypt.mjs --build
         shell: bash
 
       - id: upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build ${{ matrix.os }} Prebuild
-        run: node .github/scripts/libmongocrypt.mjs ${{ runner.os == 'Windows' && '--build' || '' }}
+        run: node .github/scripts/libmongocrypt.mjs
         shell: bash
 
       - id: upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build ${{ matrix.os }} Prebuild
-        run: node .github/scripts/libmongocrypt.mjs
+        run: node .github/scripts/libmongocrypt.mjs ${{ runner.os == 'Windows' && '--build' || '' }}
         shell: bash
 
       - id: upload

--- a/binding.gyp
+++ b/binding.gyp
@@ -68,7 +68,8 @@
                 '<(module_root_dir)/deps/lib/mongocrypt-static.lib',
                 '<(module_root_dir)/deps/lib/kms_message-static.lib',
                 '<(module_root_dir)/deps/lib/bson-static-for-libmongocrypt.lib',
-                '-lws2_32'
+                '-lws2_32',
+                '-lbcrypt'
               ]
             }
           }]

--- a/binding.gyp
+++ b/binding.gyp
@@ -68,8 +68,7 @@
                 '<(module_root_dir)/deps/lib/mongocrypt-static.lib',
                 '<(module_root_dir)/deps/lib/kms_message-static.lib',
                 '<(module_root_dir)/deps/lib/bson-static-for-libmongocrypt.lib',
-                '-lws2_32',
-                '-lbcrypt'
+                '-lws2_32'
               ]
             }
           }]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.15.1",
+  "mongodb:libmongocrypt": "1.19.2",
   "dependencies": {
     "node-addon-api": "^8.5.0",
     "prebuild-install": "^7.1.3"


### PR DESCRIPTION
## Summary

Bumps `mongodb:libmongocrypt` to `1.19.2`.
libmongocrypt 1.18.0+ is no longer published to the S3 release bucket (MONGOCRYPT-841). Starting with 1.19.2 (MONGOCRYPT-942), GitHub Releases tarballs include static archives (`.a`/`.lib`) required for the native addon static link.

[NODE-7569](https://jira.mongodb.org/browse/NODE-7569)