### PR TITLE
feat(NODE-7653): bump libmongocrypt to 1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.19.2",
+  "mongodb:libmongocrypt": "1.20.0",
   "dependencies": {
     "node-addon-api": "^8.6.0",
     "prebuild-install": "^7.1.3"


### PR DESCRIPTION
### Description

#### Summary of Changes

<!-- Please describe the changes in this PR in a high-level overview. -->

Bump libmongrocrypt to get new stable substring API, more info in the libmongocrypt release page:
https://github.com/mongodb/libmongocrypt/releases/tag/1.20.0

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
