### PR TITLE
fix(NODE-7704): build libmongocrypt for both macOS architectures

### DIFF
--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -7,7 +7,7 @@ import { createWriteStream } from 'node:fs';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { spawn } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import { once } from 'node:events';
 import {
   buildLibmongocryptDownloadUrl,
@@ -112,9 +112,19 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
       })
       : [];
 
+  // macOS builds libmongocrypt from source so that it uses the crypto hooks we provide from
+  // Node.js' copy of OpenSSL. The published libmongocrypt artifacts are built against native
+  // crypto, which is why we compile our own here.
+  //
+  // The addon itself is a universal binary (see the OTHER_CFLAGS/OTHER_LDFLAGS in binding.gyp),
+  // so libmongocrypt has to cover both architectures too. cmake targets only the host
+  // architecture unless CMAKE_OSX_ARCHITECTURES says otherwise.
   const DARWIN_CMAKE_FLAGS =
     process.platform === 'darwin' // The minimum darwin target version we want for
-      ? toCLIFlags({ DCMAKE_OSX_DEPLOYMENT_TARGET: '10.12' })
+      ? toCLIFlags({
+        DCMAKE_OSX_DEPLOYMENT_TARGET: '10.12',
+        DCMAKE_OSX_ARCHITECTURES: 'x86_64;arm64'
+      })
       : [];
 
   const cmakeProgram = process.platform === 'win32' ? 'cmake.exe' : 'cmake';
@@ -129,6 +139,63 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
     cwd: nodeBuildRoot,
     shell: process.platform === 'win32'
   });
+
+  if (process.platform === 'darwin') {
+    await checkUniversalArchives(nodeDepsRoot);
+  }
+}
+
+const DARWIN_ARCHITECTURES = ['x86_64', 'arm64'];
+
+/**
+ * Linking the addon against an archive that lacks one of the architectures is not an error: ld
+ * skips the archive with a warning, and the symbols it should have provided go missing from that
+ * slice of the addon. Check here so the problem is reported where it starts.
+ */
+async function checkUniversalArchives(nodeDepsRoot) {
+  const libDir = resolveRoot(nodeDepsRoot, 'lib');
+  const archives = (await fs.readdir(libDir)).filter(name => name.endsWith('.a'));
+
+  if (archives.length === 0) {
+    throw new Error(`no static archives found in ${libDir}`);
+  }
+
+  for (const archive of archives) {
+    const archivePath = path.join(libDir, archive);
+    const archs = execSync(`lipo -archs "${archivePath}"`, { encoding: 'utf8' }).trim().split(/\s+/);
+    const missing = DARWIN_ARCHITECTURES.filter(arch => !archs.includes(arch));
+
+    if (missing.length > 0) {
+      throw new Error(
+        `${archive} is missing ${missing.join(', ')}. libmongocrypt must cover ${DARWIN_ARCHITECTURES.join(' and ')}, got: ${archs.join(' ')}`
+      );
+    }
+  }
+
+  console.error(`libmongocrypt archives cover ${DARWIN_ARCHITECTURES.join(' and ')}`);
+}
+
+/**
+ * A bundle is allowed to have undefined symbols, which are looked up in the flat namespace when
+ * the addon is loaded. libmongocrypt is linked statically, so anything left undefined here means
+ * the link silently dropped it and loading the addon will fail with ERR_DLOPEN_FAILED.
+ */
+function checkAddonSymbols(addonPath) {
+  for (const arch of DARWIN_ARCHITECTURES) {
+    const output = execSync(`nm -arch ${arch} -u "${addonPath}"`, { encoding: 'utf8' });
+    const undefinedSymbols = output
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.includes('mongocrypt'));
+
+    if (undefinedSymbols.length > 0) {
+      throw new Error(
+        `${undefinedSymbols.length} undefined libmongocrypt symbols in the ${arch} slice of ${addonPath}, starting with ${undefinedSymbols[0]}`
+      );
+    }
+  }
+
+  console.error(`addon has no undefined libmongocrypt symbols in either architecture`);
 }
 
 async function verifySignature(tarballPath, ref, prebuild) {
@@ -225,7 +292,19 @@ async function buildBindings(args, pkg) {
   // Compile Typescript
   await run('npm', ['run', 'prepare']);
 
-  if (process.platform === 'darwin' && process.arch === 'arm64') {
+  if (process.platform === 'darwin' && process.arch === 'arm64' && !args.dynamic) {
+    const addonPath = resolveRoot('build', 'Release', 'mongocrypt.node');
+
+    const archs = execSync(`lipo -archs "${addonPath}"`, { encoding: 'utf8' }).trim().split(/\s+/);
+    const missing = DARWIN_ARCHITECTURES.filter(arch => !archs.includes(arch));
+    if (missing.length > 0) {
+      throw new Error(
+        `the addon is missing ${missing.join(', ')}, so it cannot be published as darwin-x64. Got: ${archs.join(' ')}`
+      );
+    }
+
+    checkAddonSymbols(addonPath);
+
     // @ts-ignore
     const {
       binary: {
@@ -234,7 +313,7 @@ async function buildBindings(args, pkg) {
         ]
       }
     } = JSON.parse(await readFile(resolveRoot('package.json'), 'utf-8'));
-    // The "arm64" build is actually a universal binary
+    // The "arm64" build is a universal binary, so it serves as the x64 prebuild as well
     const armTar = `mongodb-client-encryption-v${pkg.version}-napi-v${napiVersion}-darwin-arm64.tar.gz`;
     const x64Tar = `mongodb-client-encryption-v${pkg.version}-napi-v${napiVersion}-darwin-x64.tar.gz`;
     await fs.copyFile(resolveRoot('prebuilds', armTar), resolveRoot('prebuilds', x64Tar));

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -115,29 +115,36 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
   // macOS builds libmongocrypt from source so that it uses the crypto hooks we provide from
   // Node.js' copy of OpenSSL. The published libmongocrypt artifacts are built against native
   // crypto, which is why we compile our own here.
-  //
-  // The addon itself is a universal binary (see the OTHER_CFLAGS/OTHER_LDFLAGS in binding.gyp),
-  // so libmongocrypt has to cover both architectures too. cmake targets only the host
-  // architecture unless CMAKE_OSX_ARCHITECTURES says otherwise.
   const DARWIN_CMAKE_FLAGS =
     process.platform === 'darwin' // The minimum darwin target version we want for
-      ? toCLIFlags({
-        DCMAKE_OSX_DEPLOYMENT_TARGET: '10.12',
-        DCMAKE_OSX_ARCHITECTURES: 'x86_64;arm64'
-      })
+      ? toCLIFlags({ DCMAKE_OSX_DEPLOYMENT_TARGET: '10.12' })
       : [];
+
+  // The addon is a universal binary (see the OTHER_CFLAGS/OTHER_LDFLAGS in binding.gyp), so
+  // libmongocrypt has to cover both architectures too. cmake builds for the host architecture
+  // alone unless CMAKE_OSX_ARCHITECTURES says otherwise.
+  //
+  // This goes through the environment, which is where cmake reads the default for the cache
+  // variable, and is how libmongocrypt's own release build asks for a universal build. Passing it
+  // as -DCMAKE_OSX_ARCHITECTURES instead breaks the try_compile checks in the embedded
+  // mongo-c-driver, whose command line the semicolon in the value splits apart.
+  const cmakeEnv =
+    process.platform === 'darwin'
+      ? { ...process.env, CMAKE_OSX_ARCHITECTURES: 'x86_64;arm64' }
+      : process.env;
 
   const cmakeProgram = process.platform === 'win32' ? 'cmake.exe' : 'cmake';
 
   await run(
     cmakeProgram,
     [...CMAKE_FLAGS, ...WINDOWS_CMAKE_FLAGS, ...DARWIN_CMAKE_FLAGS, libmongocryptRoot],
-    { cwd: nodeBuildRoot, shell: process.platform === 'win32' }
+    { cwd: nodeBuildRoot, shell: process.platform === 'win32', env: cmakeEnv }
   );
 
   await run(cmakeProgram, ['--build', '.', '--target', 'install', '--config', 'RelWithDebInfo'], {
     cwd: nodeBuildRoot,
-    shell: process.platform === 'win32'
+    shell: process.platform === 'win32',
+    env: cmakeEnv
   });
 
   if (process.platform === 'darwin') {

--- a/.github/scripts/libmongocrypt.mjs
+++ b/.github/scripts/libmongocrypt.mjs
@@ -154,6 +154,18 @@ export async function buildLibMongoCrypt(libmongocryptRoot, nodeDepsRoot, option
 
 const DARWIN_ARCHITECTURES = ['x86_64', 'arm64'];
 
+/** Throws unless the Mach-O file at `filePath` covers both architectures. */
+function assertUniversal(filePath, description) {
+  const archs = execSync(`lipo -archs "${filePath}"`, { encoding: 'utf8' }).trim().split(/\s+/);
+  const missing = DARWIN_ARCHITECTURES.filter(arch => !archs.includes(arch));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `${description} is missing ${missing.join(', ')}, it must cover ${DARWIN_ARCHITECTURES.join(' and ')}. Got: ${archs.join(' ')}`
+    );
+  }
+}
+
 /**
  * Linking the addon against an archive that lacks one of the architectures is not an error: ld
  * skips the archive with a warning, and the symbols it should have provided go missing from that
@@ -168,15 +180,7 @@ async function checkUniversalArchives(nodeDepsRoot) {
   }
 
   for (const archive of archives) {
-    const archivePath = path.join(libDir, archive);
-    const archs = execSync(`lipo -archs "${archivePath}"`, { encoding: 'utf8' }).trim().split(/\s+/);
-    const missing = DARWIN_ARCHITECTURES.filter(arch => !archs.includes(arch));
-
-    if (missing.length > 0) {
-      throw new Error(
-        `${archive} is missing ${missing.join(', ')}. libmongocrypt must cover ${DARWIN_ARCHITECTURES.join(' and ')}, got: ${archs.join(' ')}`
-      );
-    }
+    assertUniversal(path.join(libDir, archive), archive);
   }
 
   console.error(`libmongocrypt archives cover ${DARWIN_ARCHITECTURES.join(' and ')}`);
@@ -302,14 +306,9 @@ async function buildBindings(args, pkg) {
   if (process.platform === 'darwin' && process.arch === 'arm64' && !args.dynamic) {
     const addonPath = resolveRoot('build', 'Release', 'mongocrypt.node');
 
-    const archs = execSync(`lipo -archs "${addonPath}"`, { encoding: 'utf8' }).trim().split(/\s+/);
-    const missing = DARWIN_ARCHITECTURES.filter(arch => !archs.includes(arch));
-    if (missing.length > 0) {
-      throw new Error(
-        `the addon is missing ${missing.join(', ')}, so it cannot be published as darwin-x64. Got: ${archs.join(' ')}`
-      );
-    }
-
+    // The copy below publishes this same file as the darwin-x64 prebuild, so it has to carry both
+    // architectures and have everything resolved in each of them.
+    assertUniversal(addonPath, 'the addon');
     checkAddonSymbols(addonPath);
 
     // @ts-ignore
@@ -329,7 +328,7 @@ async function buildBindings(args, pkg) {
 
 async function main() {
   const { pkg, ...args } = await parseArguments();
-  console.log(args);
+  console.error(args);
 
   const nodeDepsDir = resolveRoot('deps');
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
   # process is the only way to exercise its x86_64 half.
   test_macos_x64_prebuild:
     needs: host_builds
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     strategy:
       matrix:
         node: [20.19.0, 22.x, 24.x]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,38 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  # The macOS prebuild is universal and is built on an arm64 runner, so loading it in an x64
+  # process is the only way to exercise its x86_64 half.
+  test_macos_x64_prebuild:
+    needs: host_builds
+    runs-on: macos-15-intel
+    strategy:
+      matrix:
+        node: [20.19.0, 22.x, 24.x]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Download the macOS prebuild
+        uses: actions/download-artifact@v7
+        with:
+          name: build-macos-latest
+          path: prebuilds/
+
+      # Install without scripts so the prebuild we just downloaded is the one under test
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Unpack the prebuild
+        run: tar -xzf prebuilds/*darwin-arm64.tar.gz
+
+      - name: Test the prebuild on x64
+        run: npm run test
+
   container_builds_glibc:
     outputs:
       artifact_id: ${{ steps.upload.outputs.artifact-id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   host_tests:
     strategy:
       matrix:
-        os: [macos-latest, macos-15-intel, windows-2022]
+        os: [macos-latest, macos-26-intel, windows-2022]
         node: [20.19.0, 22.x, 24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   host_tests:
     strategy:
       matrix:
-        os: [macos-latest, windows-2022]
+        os: [macos-latest, macos-15-intel, windows-2022]
         node: [20.19.0, 22.x, 24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Build with Node.js ${{ matrix.node }} on ${{ matrix.os }}
-        run: node .github/scripts/libmongocrypt.mjs ${{ runner.os == 'Windows' && '--build' || '' }}
+        run: node .github/scripts/libmongocrypt.mjs --build
         shell: bash
 
       - name: Test ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "Apache-2.0",
   "gypfile": true,
-  "mongodb:libmongocrypt": "1.20.0",
+  "mongodb:libmongocrypt": "1.20.1",
   "dependencies": {
     "node-addon-api": "^8.6.0",
     "prebuild-install": "^7.1.3"


### PR DESCRIPTION
### Description

#### Summary of Changes

The macOS prebuild is a universal binary, but only the arm64 half was complete. cmake built libmongocrypt for the host architecture only, while binding.gyp builds the addon for both, so the x86_64 slice linked against arm64 archives and lost all 67 libmongocrypt symbols. `ld` only warns on a wrong-architecture archive, and a bundle is allowed to have undefined symbols, so the build passed and `file`, `lipo` and `otool -L` all looked fine. Any x64 Node.js process fails to load it with `ERR_DLOPEN_FAILED`.

This sets `CMAKE_OSX_ARCHITECTURES` for the libmongocrypt build, and adds checks so a broken binary can't ship quietly again:

- the static archives must cover both architectures after the cmake install
- neither slice of the addon may have undefined `mongocrypt_*` symbols, checked before the darwin-x64 tarball is copied from the arm64 one
- a new job in `build.yml` runs the test suite on `macos-26-intel` against the arm64-built prebuild, which is exactly the case that broke

`test.yml` now builds libmongocrypt from source on macOS like `build.yml` does, so we test what we ship, and it gains a `macos-26-intel` entry.

##### Notes for Reviewers

**The libmongocrypt 1.20.1 bump is unrelated to the bug**, but macOS can't build without it. The runners now have cmake 4.4.0, and 1.20.0's libbson 2.3.0 fails to configure with it. This was already broken on main, we just hadn't run macOS CI since the 7.2.0 release on July 6. Happy to split it out if you'd rather.

Verified locally on cmake 4.4.0: archives universal, addon universal, zero undefined symbols in either slice, tests pass. In CI, `test_macos_x64_prebuild` passes on Node 20, 22 and 24, running an x64 process against the arm64-built artifact.

Follow-ups filed rather than fixed here:

- NODE-7727: libmongocrypt is built with deployment target 10.12 while the addon uses 11, which is where Copilot's comment lands
- NODE-7723, under NODE-7720: pin GitHub Actions to commit SHAs, which covers the Semgrep findings on this PR

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### macOS x64 prebuild

Fixes `ERR_DLOPEN_FAILED` when loading the addon in an x64 Node.js process on macOS. The x86_64 half of the universal binary in 7.1.0 and 7.2.0 was missing libmongocrypt's symbols. arm64 processes and 7.0.0 are not affected.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
